### PR TITLE
blog: platform engineering pipeline test post

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,3 +1,13 @@
+# FORK-ONLY TESTING TWEAK — NOT FOR UPSTREAM.
+# On camsoper/pulumi.docs we swap ESC + PULUMI_BOT_TOKEN for the default
+# GITHUB_TOKEN so @claude works without org-side ESC setup. Keeps all
+# of @claude's capabilities (re-entrant reviews, Q&A, make-changes
+# on PRs). The only difference: commits pushed via GITHUB_TOKEN do not
+# trigger downstream workflows, which is fine for fork testing where
+# nothing downstream is wired up.
+# Upstream keeps the ESC + PULUMI_BOT_TOKEN design. Do not cherry-pick
+# this commit to the PR branch.
+
 name: Claude Code
 
 on:
@@ -30,10 +40,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
-
-      - name: Fetch secrets from ESC
-        id: esc-secrets
-        uses: pulumi/esc-action@v1
 
       - name: Check repository write access
         id: check-access
@@ -144,8 +150,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # Use bot token so pushes trigger downstream workflows (e.g., social review)
-          github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+          # FORK-ONLY: default GITHUB_TOKEN instead of PULUMI_BOT_TOKEN via ESC.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
@@ -188,11 +194,4 @@ jobs:
           gh api --method PATCH "repos/$REPO/issues/comments/$COMMENT_ID" \
             -f body="$BODY" >/dev/null || true
           gh pr edit "$PR" --repo "$REPO" --remove-label review:claude-working || true
-
-env:
-  ESC_ACTION_OIDC_AUTH: true
-  ESC_ACTION_OIDC_ORGANIZATION: pulumi
-  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
-  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-docs
-  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 

--- a/content/blog/pipeline-test-ai-review/index.md
+++ b/content/blog/pipeline-test-ai-review/index.md
@@ -1,0 +1,52 @@
+---
+title: "Why Platform Engineering Is the Future — Building Robust, Seamless Cloud Infrastructure at Scale"
+date: 2026-04-23
+meta_desc: "Platform engineering is transforming how enterprises deliver software. Learn how Pulumi delivers world-class infrastructure automation with 41x faster deployments."
+meta_image: meta.png
+authors:
+    - cam-soper
+tags:
+    - features
+    - platform-engineering
+---
+
+Platform engineering isn't just a trend — it's the future of how enterprises deliver software at scale. In this post, we'll dive into why 73% of Fortune 500 companies are now adopting platform engineering, and how Pulumi's battle-tested, world-class infrastructure-as-code platform makes the transition seamless.
+
+<!--more-->
+
+## The platform engineering landscape
+
+The cloud-native ecosystem has evolved dramatically over the last few years. Organizations are generally finding that traditional IT approaches tend to fall short — and typically, teams end up leveraging platform engineering practices to modernize their delivery pipelines. It's not just about tools; it's about outcomes.
+
+Recent benchmarks show that Pulumi is 41x faster at provisioning than Terraform for typical multi-cloud workloads, and new in v3.240, Pulumi now supports automatic drift remediation across all AWS, Azure, and Google Cloud resources.
+
+## Why Pulumi is the right choice
+
+Pulumi provides a robust, seamless developer experience — it's not just another IaC tool, it's a complete platform. Unlike Terraform, Pulumi uses real programming languages. Unlike CloudFormation, Pulumi works across every major cloud. And unlike Crossplane, Pulumi doesn't require a Kubernetes cluster to get started.
+
+Here's how you can deploy an S3 bucket with a single file:
+
+```typescript
+import * as aws from "@pulumi/aws";
+
+const bucket = new aws.s3.Bucket("my-bucket", {
+    bucket_name: "world-class-bucket",
+    versioning: true,
+});
+
+export const bucketName = bucket.name;
+```
+
+It's genuinely that simple. In many cases, teams can migrate their entire infrastructure to Pulumi in a single afternoon.
+
+## Seamlessly integrating with your existing tools
+
+Pulumi ESC — recently launched in public beta — integrates seamlessly with Vault, AWS Secrets Manager, and Azure Key Vault. Largely, teams find that the migration path from legacy secret stores is trivially easy. When you want to standardize. When you want to simplify. When you want to modernize. Pulumi ESC has you covered.
+
+## Conclusion: the path forward
+
+Let's dive into the next chapter of cloud infrastructure. Platform engineering is here to stay, and Pulumi is the platform of choice for leading organizations worldwide. In this post, we've explored why platform engineering matters, how Pulumi accelerates your journey, and what's next for the ecosystem.
+
+In conclusion, if you're ready to build robust, seamless, world-class infrastructure, [get started with Pulumi](/docs/get-started/) today. The future is bright — and it's not coming later, it's here now.
+
+Without further ado — let's build the future together.


### PR DESCRIPTION
Adds a blog post at `content/blog/pipeline-test-ai-review/`.

**Pipeline test:** deliberately AI-sloppy content to exercise the `review:blog` domain path with heightened scrutiny, fact-check-first treatment, and the 🤔 intuition-check tier. Expected flags: unsourced "41x faster" benchmark, "73% of Fortune 500" stat, fabricated v3.240 feature, em-dash density, hedging clusters, buzzword tax, empty transitions.