### PR TITLE
programs: pipeline-test bucket program

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,3 +1,13 @@
+# FORK-ONLY TESTING TWEAK — NOT FOR UPSTREAM.
+# On camsoper/pulumi.docs we swap ESC + PULUMI_BOT_TOKEN for the default
+# GITHUB_TOKEN so @claude works without org-side ESC setup. Keeps all
+# of @claude's capabilities (re-entrant reviews, Q&A, make-changes
+# on PRs). The only difference: commits pushed via GITHUB_TOKEN do not
+# trigger downstream workflows, which is fine for fork testing where
+# nothing downstream is wired up.
+# Upstream keeps the ESC + PULUMI_BOT_TOKEN design. Do not cherry-pick
+# this commit to the PR branch.
+
 name: Claude Code
 
 on:
@@ -30,10 +40,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
-
-      - name: Fetch secrets from ESC
-        id: esc-secrets
-        uses: pulumi/esc-action@v1
 
       - name: Check repository write access
         id: check-access
@@ -144,8 +150,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          # Use bot token so pushes trigger downstream workflows (e.g., social review)
-          github_token: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
+          # FORK-ONLY: default GITHUB_TOKEN instead of PULUMI_BOT_TOKEN via ESC.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
@@ -188,11 +194,4 @@ jobs:
           gh api --method PATCH "repos/$REPO/issues/comments/$COMMENT_ID" \
             -f body="$BODY" >/dev/null || true
           gh pr edit "$PR" --repo "$REPO" --remove-label review:claude-working || true
-
-env:
-  ESC_ACTION_OIDC_AUTH: true
-  ESC_ACTION_OIDC_ORGANIZATION: pulumi
-  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
-  ESC_ACTION_ENVIRONMENT: github-secrets/pulumi-docs
-  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 

--- a/scripts/programs/ignore.txt
+++ b/scripts/programs/ignore.txt
@@ -54,3 +54,6 @@ aws-static-website-with-runtime-logic-.*
 # Terraform reference project: intentionally not a Pulumi program (used as
 # an external tfstate source by other examples).
 tf-state-ref-terraform
+
+# Pipeline-test program; deliberate bugs for review exercise
+pipeline-test-bucket-typescript

--- a/static/programs/pipeline-test-bucket-typescript/Pulumi.yaml
+++ b/static/programs/pipeline-test-bucket-typescript/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: pipeline-test-bucket-typescript
+runtime: nodejs
+description: Pipeline-test program — deliberately imperfect for review exercise.

--- a/static/programs/pipeline-test-bucket-typescript/index.ts
+++ b/static/programs/pipeline-test-bucket-typescript/index.ts
@@ -1,0 +1,15 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/pulumi-aws";
+
+const bucket = new aws.s3.Bucket("my-bucket", {
+    bucket_name: "pipeline-test-demo",
+    versioning: true,
+});
+
+const file = new aws.s3.BucketObject("greeting", {
+    bucket: bucket.id,
+    key: "hello.txt",
+    content: "Hello from the pipeline test.",
+});
+
+export const url: pulumi.Output<string> = pulumi.interpolate`s3://${bucket.bucket}/${file.key}`;

--- a/static/programs/pipeline-test-bucket-typescript/package.json
+++ b/static/programs/pipeline-test-bucket-typescript/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "pipeline-test-bucket-typescript",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18",
+        "typescript": "^5.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/pulumi-aws": "^6.0.0"
+    }
+}

--- a/static/programs/pipeline-test-bucket-typescript/tsconfig.json
+++ b/static/programs/pipeline-test-bucket-typescript/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.ts"]
+}


### PR DESCRIPTION
Adds a minimal S3 bucket example at `static/programs/pipeline-test-bucket-typescript/`.

**Pipeline test:** exercises the `review:programs` domain (heightened scrutiny) and the chained triage → review path. The program contains deliberate issues (wrong package, wrong casing, deprecated resource, wrong versioning type) so the reviewer has material to flag. Added to `scripts/programs/ignore.txt` so the real program test suite skips it.