### PR TITLE
programs: add pipeline-test S3 versioning TS example

### DIFF
--- a/static/programs/pipeline-test-s3-versioning-typescript/Pulumi.yaml
+++ b/static/programs/pipeline-test-s3-versioning-typescript/Pulumi.yaml
@@ -1,0 +1,7 @@
+name: pipeline-test-s3-versioning-typescript
+runtime: nodejs
+description: Pipeline-test program. Creates an S3 bucket with versioning enabled.
+config:
+  pulumi:tags:
+    value:
+      pulumi:template: aws-typescript

--- a/static/programs/pipeline-test-s3-versioning-typescript/index.ts
+++ b/static/programs/pipeline-test-s3-versioning-typescript/index.ts
@@ -1,0 +1,16 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const bucket = new aws.s3.BucketV2("content-bucket", {
+    bucket: "pipeline-test-content-bucket",
+});
+
+const versioning = new aws.s3.BucketVersioningV2("content-bucket-versioning", {
+    bucket: bucket.id,
+    versioningConfiguration: {
+        status: "Enabled",
+    },
+});
+
+export const bucketName = bucket.id;
+export const bucketArn = bucket.arn;

--- a/static/programs/pipeline-test-s3-versioning-typescript/package.json
+++ b/static/programs/pipeline-test-s3-versioning-typescript/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "pipeline-test-s3-versioning-typescript",
+    "main": "index.ts",
+    "devDependencies": {
+        "@types/node": "^18"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^3.0.0",
+        "@pulumi/aws": "^7.0.0"
+    }
+}

--- a/static/programs/pipeline-test-s3-versioning-typescript/tsconfig.json
+++ b/static/programs/pipeline-test-s3-versioning-typescript/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": ["index.ts"]
+}


### PR DESCRIPTION
New TypeScript program under `static/programs/` creating an S3 bucket with versioning. Seeded with one real risk a reviewer should flag: the hard-coded `bucket: "pipeline-test-content-bucket"` name is not globally unique and will collide across stacks or regions. Tests programs-domain code-correctness review.