### PR TITLE
docs+programs: local backends note; ACM example cleanup

### DIFF
--- a/content/docs/iac/concepts/how-pulumi-works.md
+++ b/content/docs/iac/concepts/how-pulumi-works.md
@@ -43,6 +43,8 @@ The _deployment engine_ is responsible for computing the set of operations neede
 
 The deployment engine is embedded in the `pulumi` CLI itself.
 
+Because the engine runs locally, Pulumi programs can be developed and tested without contacting the Pulumi Cloud service. Local state backends (filesystem, S3, Azure Blob, GCS) work entirely offline once the required provider plugins are cached.
+
 ## Resource providers
 
 A resource provider is made up of two different pieces:

--- a/static/programs/aws-acm-certificate-typescript/index.ts
+++ b/static/programs/aws-acm-certificate-typescript/index.ts
@@ -1,7 +1,13 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 
-let certCertificate = new aws.acm.Certificate("cert", {
+const certCertificate = new aws.acm.Certificate("cert", {
     domainName: "example.com",
     validationMethod: "DNS",
+    tags: {
+        Environment: "pipeline-test",
+        ManagedBy: "pulumi",
+    },
 });
+
+export const certificateArn = certCertificate.arn;


### PR DESCRIPTION
Two-domain PR touching both `content/docs/` and `static/programs/`:

- Adds a short paragraph to the Pulumi Architecture page about offline/local-backend operation.
- Cleans up the ACM certificate example: `let` → `const`, adds `tags`, exports the ARN.

Tests `review:mixed` label application and multi-domain review composition (review-docs.md + review-programs.md both compose under review-shared.md).