### PR TITLE
test3: prose-check (negative — clean)

### DIFF
--- a/content/docs/iac/concepts/config.md
+++ b/content/docs/iac/concepts/config.md
@@ -60,7 +60,7 @@ $ pulumi config get aws:region
 us-west-2
 ```
 
-To set and get configuration in the current project (named `broome-proj` for example), we can use the simplified key name:
+To set and get configuration in the current project (named `broome-proj` for instance), we can use the simplified key name:
 
 ```bash
 $ pulumi config set name BroomeLLC


### PR DESCRIPTION
Pipeline test for the new triage prose-check feature. Single-line prose change with no errors (for example → for instance). Expecting: review:trivial label + NO TRIAGE_PROSE comment + full review skipped.