### PR TITLE
test4: Phase A end-to-end (config listing docs)

### DIFF
--- a/content/docs/iac/concepts/config.md
+++ b/content/docs/iac/concepts/config.md
@@ -46,7 +46,7 @@ The `pulumi config` CLI command can get, set, or list configuration key-value pa
 
 * `pulumi config set <key> [value]` sets a configuration entry `<key>` to `[value]`.
 * `pulumi config get <key>` gets an existing configuration value with the key `<key>`.
-* `pulumi config` gets all configuration key-value pairs in the current stack (as JSON if `--json` is passed).
+* `pulumi config` lists all configuration key-value pairs in the current stack — see [Listing all configuration values](#listing-all-configuration-values) for details and example output.
 
 {{% notes "info" %}}
 When using the `config set` command, any existing values for `<key>` will be overridden without warning.
@@ -76,7 +76,7 @@ $ cat my_key.pub | pulumi config set publicKey
 
 ### Listing all configuration values
 
-To see every key currently set on the active stack, run `pulumi config` with no subcommand:
+To see every key currently set on the current stack, run `pulumi config` with no subcommand:
 
 ```bash
 $ pulumi config

--- a/content/docs/iac/concepts/config.md
+++ b/content/docs/iac/concepts/config.md
@@ -74,6 +74,19 @@ If `[value]` is not specified when setting a configuration key, the CLI will pro
 $ cat my_key.pub | pulumi config set publicKey
 ```
 
+### Listing all configuration values
+
+To see every key currently set on the active stack, run `pulumi config` with no subcommand:
+
+```bash
+$ pulumi config
+KEY              VALUE
+aws:region       us-west-2
+myproject:size   t3.micro
+```
+
+Pass `--json` to get machine-readable output for scripting.
+
 ## Using the Config Flag with `pulumi new`
 
 Configuration keys and values can be passed when using `pulumi new`.

--- a/content/docs/iac/concepts/how-pulumi-works.md
+++ b/content/docs/iac/concepts/how-pulumi-works.md
@@ -41,7 +41,7 @@ The _language host_ is responsible for running a Pulumi program and setting up a
 
 The _deployment engine_ is responsible for computing the set of operations needed to drive the current state of your infrastructure into the desired state expressed by your program. When a _resource registration_ is received from the language host, the engine consults the existing [state](/docs/iac/concepts/state-and-backends/) to determine if that resource has been created before. If it has not, the engine uses a _resource provider_ to create it. If it already exists, the engine works with the resource provider to determine what, if anything, has changed by comparing the old state of the resource with the new desired state of the resource as expressed by the program. If there are changes, the engine determines if it can _update_ the resource in place or if it must _replace_ it by _creating_ a new version and _deleting_ the old version. The decision depends on what properties of the resource are changing and the type of the resource itself. When the language host communicates to the engine that it has completed the execution of the Pulumi program, the engine looks for any existing resources that it did not see a new resource registration and schedules these resources for deletion.
 
-The deployment engine is embedded in the `pulumi` CLI itself.
+The deployment engine is embedded in the `pulumi` CLI itself. After each successful operation, the deployment engine writes state changes back to the configured [backend](/docs/iac/concepts/state-and-backends/).
 
 ## Resource providers
 


### PR DESCRIPTION
Test PR for Phase A pipeline changes. ~13 line non-trivial docs addition. Expecting: triage labels review:docs, review fires (Opus), 🤖 emoji + 'several minutes' progress comment, check-run in PR Checks UI.