### PR TITLE
test6: prose-check FP guardrail + idempotency

### DIFF
--- a/content/docs/iac/concepts/how-pulumi-works.md
+++ b/content/docs/iac/concepts/how-pulumi-works.md
@@ -41,7 +41,7 @@ The _language host_ is responsible for running a Pulumi program and setting up a
 
 The _deployment engine_ is responsible for computing the set of operations needed to drive the current state of your infrastructure into the desired state expressed by your program. When a _resource registration_ is received from the language host, the engine consults the existing [state](/docs/iac/concepts/state-and-backends/) to determine if that resource has been created before. If it has not, the engine uses a _resource provider_ to create it. If it already exists, the engine works with the resource provider to determine what, if anything, has changed by comparing the old state of the resource with the new desired state of the resource as expressed by the program. If there are changes, the engine determines if it can _update_ the resource in place or if it must _replace_ it by _creating_ a new version and _deleting_ the old version. The decision depends on what properties of the resource are changing and the type of the resource itself. When the language host communicates to the engine that it has completed the execution of the Pulumi program, the engine looks for any existing resources that it did not see a new resource registration and schedules these resources for deletion.
 
-The deployment engine is embedded in the `pulumi` CLI itself.
+The deployment engine is embeded in the `pulumi` CLI itself.
 
 ## Resource providers
 


### PR DESCRIPTION
Single-line trivial change with a typo (embedded → embeded) AND a technical term ('pulumi' CLI in backticks). Expecting: review:trivial label + TRIAGE_PROSE flagging the typo only (NOT the CLI name).