### PR TITLE
Test-v5

### DIFF
--- a/content/docs/iac/concepts/projects/_index.md
+++ b/content/docs/iac/concepts/projects/_index.md
@@ -26,11 +26,12 @@ A Pulumi project is any folder that contains a `Pulumi.yaml` project file. At ru
 
 ## The project file (Pulumi.yaml) {#pulumi-yaml}
 
-The project file specifies which runtime to use and determines where to look for the program that should be executed during deployments. Supported runtimes are `nodejs`, `python`, `dotnet`, `go`, `java`, and `yaml`.
+The project file specifies which runtime to use and where to find the program that runs during each deployment.
+Supported runtimes are `nodejs`, `python`, `dotnet`, `go`, `java`, and `yaml`.
 
-Project files also contain metadata about your project. The project file must begin with a capital `P`, although either `.yml` or `.yaml` extension will work.
+Project files also include metadata about your project. The filename must start with a capital `P`, but either `.yml` or `.yaml` extension is accepted.
 
-A typical `Pulumi.yaml` file looks like the following:
+A typical `Pulumi.yaml` file looks similar to the following example:
 
 ```yaml
 name: webserver


### PR DESCRIPTION
Boundary fixture for the Session-17 trivial-threshold bump (`triage-classify.py:245-246`, `<=5` → `<=10` lines, `==1` → `<=2` files).

 7-line wording polish (boundary above old cap, below new): 1 file / 7 lines should label review:trivial after Session-17 bump (was full review).

Session-18 e2e test artifacts in scratch/2026-04-30-e2e-test-v3/.