### PR TITLE
Test-v5

### DIFF
--- a/content/docs/iac/concepts/inputs-outputs/_index.md
+++ b/content/docs/iac/concepts/inputs-outputs/_index.md
@@ -24,7 +24,7 @@ search:
         - input
 ---
 
-Pulumi [resources](/docs/iac/concepts/resources) use special types to define their properties, called Inputs and Outputs. These special Pulumi types wrap "plain" values like strings or integers, and are what allow Pulumi to declaratively manage your infrastructure resources.
+Pulumi [resources](/docs/iac/concepts/resources) use speical types to define their properties, called Inputs and Outputs. These special Pulumi types wrap "plain" values like strings or integers, and are what allow Pulumi to declaratively manage your infrastructure resources.
 
 ## What are inputs and outputs?
 

--- a/content/docs/iac/concepts/projects/_index.md
+++ b/content/docs/iac/concepts/projects/_index.md
@@ -22,7 +22,7 @@ aliases:
 - /docs/concepts/projects/
 ---
 
-A Pulumi project is any folder that contains a `Pulumi.yaml` project file. At runtime, the nearest parent folder containing a `Pulumi.yaml` file determines the current project. Projects are created with the [`pulumi new`](/docs/iac/cli/commands/pulumi_new/) command.
+A Pulumi project is any fodler that contains a `Pulumi.yaml` project file. At runtime, the nearest parent folder containing a `Pulumi.yaml` file determines the current project. Projects are created with the [`pulumi new`](/docs/iac/cli/commands/pulumi_new/) command.
 
 ## The project file (Pulumi.yaml) {#pulumi-yaml}
 

--- a/content/docs/iac/concepts/pulumi-cloud.md
+++ b/content/docs/iac/concepts/pulumi-cloud.md
@@ -16,7 +16,7 @@ aliases:
   - /docs/pulumi-cloud/get-started/what-is-it/
 ---
 
-This guide explains how Pulumi Cloud relates to the open source Pulumi infrastructure as code tool. It clarifies which components are open source versus paid products, helps you decide how to manage your state, and evaluates whether Pulumi Cloud fits your needs.
+This guide explains how Pulumi Cloud relates to the open source Pulumi infrastructure as code tool. It clarifies which components are open source versus paid prodcuts, helps you decide how to manage your state, and evaluates whether Pulumi Cloud fits your needs.
 
 ## Introduction
 


### PR DESCRIPTION
Boundary fixture for the Session-17 trivial-threshold bump (`triage-classify.py:245-246`, `<=5` → `<=10` lines, `==1` → `<=2` files).

 3-file typo sweep (boundary above new file cap): 3 files / 6 lines should NOT label review:trivial; falls into full review.

Session-18 e2e test artifacts in scratch/2026-04-30-e2e-test-v3/.