### PR TITLE
[bench-S34] Add executable plugin guide and restructure Packages section (#18364)

### DIFF
--- a/config/_default/menus.yml
+++ b/config/_default/menus.yml
@@ -14,10 +14,6 @@ iac:
     parent: iac-guides-building-extending
     identifier: iac-guides-components
     weight: 1
-  - name: Packages
-    parent: iac-guides-building-extending
-    identifier: iac-guides-packages
-    weight: 2
   - name: Providers
     parent: iac-guides-building-extending
     identifier: iac-guides-providers

--- a/content/docs/iac/concepts/components/_index.md
+++ b/content/docs/iac/concepts/components/_index.md
@@ -119,7 +119,7 @@ Components distributed as Pulumi packages can be consumed in any language using 
 pulumi package add github.com/my-org/my-component@v1.0.0
 ```
 
-This pattern is common for components your organization publishes for internal consumption via a Git repository or the [Pulumi IDP Private Registry](/docs/idp/concepts/private-registry/). It is also how components from a [source-based plugin package](#authoring-and-distributing-components) are consumed across languages — the SDK is generated in your program's language regardless of the language the component was authored in.
+This pattern is common for components your organization publishes for internal consumption via a Git repository or the [Pulumi IDP Private Registry](/docs/idp/concepts/private-registry/). It is also how components from a [source-based plugin package](#authoring-components) are consumed across languages — the SDK is generated in your program's language regardless of the language the component was authored in.
 
 Under the hood, Pulumi fetches the package source (e.g. from GitHub), generates a [local package](/docs/iac/guides/building-extending/packages/local-packages/) SDK from the component's schema, and makes the generated SDK available for import in your program.
 
@@ -362,21 +362,11 @@ This tree makes it clear that a single `awsx:ec2:Vpc` component encapsulates mul
 
 Resource options passed to a component resource do not always behave the same as they do for custom resources. For example, the `provider` option has no effect on a component—use `providers` instead to pass explicit provider configuration to a component's child resources. For a complete list of which options apply to component resources, see [Resource options and component resources](/docs/iac/concepts/resources/options/#resource-options-and-component-resources).
 
-## Authoring and distributing components
+## Authoring components
 
-You author a component by extending the `ComponentResource` class. For a complete walkthrough — defining the class, structuring arguments, creating child resources, registering outputs, and configuring provider inheritance — see [Build a Component](/docs/iac/guides/building-extending/components/build-a-component/).
+You author a component by extending the `ComponentResource` class. The guides below walk through building, packaging, and testing components:
 
-Once you've authored a component, there are three ways to distribute it. Two of them allow the component to be consumed from **any** Pulumi language — including YAML — regardless of the language it was authored in:
-
-- **Native language package** — publish the component class through a language-ecosystem package manager (npm, PyPI, Go modules, etc.). No Pulumi plugin is involved, and consumers must use the same language you authored in.
-- **Source-based plugin package** — distribute as source; Pulumi generates an SDK in the consumer's language at `pulumi package add` time. Consumable from any Pulumi language.
-- **Executable-based plugin package** — ship the plugin as a pre-built executable alongside per-language SDKs. Consumable from any Pulumi language and the only option with no consumer-side runtime dependencies.
-
-For the full comparison and authoring workflow, see [Packaging Components](/docs/iac/guides/building-extending/components/packaging-components/).
-
-## Additional resources
-
-- [Build a Component](/docs/iac/guides/building-extending/components/build-a-component/) — Step-by-step guide to authoring a component from scratch, including setup, implementation, and publishing.
-- [Packaging Components](/docs/iac/guides/building-extending/components/packaging-components/) — How to package and distribute components for use by others.
-- [Testing Components](/docs/iac/guides/building-extending/components/testing-components/) — How to write tests for your component resources.
-- [Pulumi IDP Private Registry](/docs/idp/concepts/private-registry/) — How to publish and discover components within your organization.
+- [Build a Component](/docs/iac/guides/building-extending/components/build-a-component/) — define the class, structure arguments, create child resources, register outputs, and configure provider inheritance.
+- [Packaging Components](/docs/iac/guides/building-extending/components/packaging-components/) — compare the three distribution options and package a component for sharing.
+- [Testing Components](/docs/iac/guides/building-extending/components/testing-components/) — write tests for component resources.
+- [Pulumi IDP Private Registry](/docs/idp/concepts/private-registry/) — publish and discover components within your organization.

--- a/content/docs/iac/concepts/packages/_index.md
+++ b/content/docs/iac/concepts/packages/_index.md
@@ -16,8 +16,6 @@ aliases:
 - /docs/iac/packages-and-automation/pulumi-packages/
 - /docs/iac/using-pulumi/pulumi-packages/
 - /docs/iac/concepts/packages/packages/
-- /docs/iac/guides/building-extending/packages/
-- /docs/iac/guides/building-extending/packages/packages/
 ---
 
 Pulumi Packages are the core technology that enables Pulumi [resources](/docs/iac/concepts/resources/), [components](/docs/iac/concepts/components/), and [functions](/docs/iac/concepts/functions/) to be defined once and used in all Pulumi languages.

--- a/content/docs/iac/guides/building-extending/_index.md
+++ b/content/docs/iac/guides/building-extending/_index.md
@@ -38,7 +38,7 @@ Package and distribute your components and providers for use across teams and pr
 
 **[Local Packages](/docs/iac/guides/building-extending/packages/local-packages/)** - Develop and test packages locally before publishing them to registries.
 
-**[Publishing Packages](/docs/iac/guides/building-extending/packages/publishing-packages/)** - Publish packages to your organization's private registry or the public Pulumi Registry.
+**[Publishing to the Pulumi Registry](/docs/iac/guides/building-extending/packages/publishing-packages/)** - Publish packages to the public Pulumi Registry. For publishing to the Pulumi IDP Private Registry, see [Publishing Components from GitHub Actions](/docs/idp/guides/publishing-from-github-actions/).
 
 **[Schema](/docs/iac/guides/building-extending/packages/schema/)** - Define package schemas that drive SDK generation and documentation for all supported languages.
 

--- a/content/docs/iac/guides/building-extending/components/packaging-components.md
+++ b/content/docs/iac/guides/building-extending/components/packaging-components.md
@@ -20,8 +20,8 @@ Once you've authored a Pulumi component, you will probably want to package and d
 The three options differ in whether the component ships as a [Pulumi package](/docs/iac/concepts/packages/) and, if so, which kind of [plugin](/docs/iac/concepts/plugins/) carries it:
 
 1. **Native language package** — a plain language-ecosystem package (npm, PyPI, Go module, etc.) containing a component class. Not a Pulumi package; no Pulumi plugin involved. A good fit for smaller organizations where all Pulumi code is written in the same language.
-1. **[Source-based plugin package](/docs/iac/guides/building-extending/packages/source-based-plugin/)** — a Pulumi package distributed as source. Pulumi generates per-language SDKs on-the-fly when a consumer adds the package, so the components can be consumed from any Pulumi language. A good fit for platform teams providing reusable abstractions and self-service.
-1. **Executable-based plugin package** — a Pulumi package whose plugin is a pre-built executable (typically a Pulumi [provider](/docs/iac/concepts/providers/)). No consumer runtime dependencies, and the package can mix in custom resources and functions alongside components. A good fit for large organizations distributing to many teams and languages, or components destined for public release in the Pulumi Registry.
+1. **Source-based plugin package** — a Pulumi package distributed as source. Pulumi generates per-language SDKs on-the-fly when a consumer adds the package, so the components can be consumed from any Pulumi language. A good fit for platform teams providing reusable abstractions and self-service. For more information, see [Authoring a source-based plugin package](/docs/iac/guides/building-extending/packages/source-based-plugin/).
+1. **Executable-based plugin package** — a Pulumi package whose plugin is a pre-built executable (typically a Pulumi [provider](/docs/iac/concepts/providers/)). No consumer runtime dependencies, and the package can mix in custom resources and functions alongside components. A good fit for large organizations distributing to many teams and languages, or components destined for public release in the Pulumi Registry. For more information, see [Authoring an executable plugin package](/docs/iac/guides/building-extending/packages/executable-plugin/).
 
 {{% notes type="info" %}}
 Most platform teams should choose a source-based plugin package by default: it enables multi-language consumption with minimal authoring overhead and integrates with Pulumi Cloud IDP.
@@ -73,7 +73,7 @@ Pulumi Cloud customers can publish versions of the package to the Pulumi IDP Pri
 
 ## Executable-based plugin packages
 
-An executable-based plugin package is a [Pulumi package](/docs/iac/concepts/packages/) whose plugin is a pre-built executable — typically a Pulumi [provider](/docs/iac/concepts/providers/). The executable has no consumer-side runtime dependencies, and the package can expose [components, custom resources, and functions](/docs/iac/concepts/resources/#resources) together. Because the authoring and CI/CD overhead is higher (and most such packages are written in Go), this approach fits very large organizations distributing to many teams and languages, environments where the source-based runtime dependencies aren't acceptable, or components intended for public release in the Pulumi Registry.
+An executable-based plugin package is a [Pulumi package](/docs/iac/concepts/packages/) whose plugin is a pre-built executable — typically a Pulumi [provider](/docs/iac/concepts/providers/). The executable has no consumer-side runtime dependencies, and the package can expose [components, custom resources, and functions](/docs/iac/concepts/resources/#resources) together. Because the authoring and CI/CD overhead is higher (and most such packages are written in Go), this approach fits very large organizations distributing to many teams and languages, environments where the source-based runtime dependencies aren't acceptable, or components intended for public release in the Pulumi Registry. For more information, see [Authoring an executable plugin package](/docs/iac/guides/building-extending/packages/executable-plugin/).
 
 {{% notes type="info" %}}
 To publish a component for public consumption in the [Pulumi Registry](/registry), author it as an executable-based plugin package in Go and publish per-language SDKs to the public feeds (npmjs.org, PyPI, etc.). See [Publishing Pulumi packages](/docs/iac/guides/building-extending/packages/publishing-packages/).
@@ -81,18 +81,18 @@ To publish a component for public consumption in the [Pulumi Registry](/registry
 
 ### Distribution and consumption
 
-Executable-based plugin packages are typically distributed as pre-built per-language SDKs published to multiple package managers (one per consumer language), with the plugin executable published to an accessible location. Pulumi Cloud customers can also publish to the Pulumi IDP Private Registry using [`pulumi package publish`](/docs/iac/cli/commands/pulumi_package_publish/).
+Executable-based plugin packages are usually distributed as pre-built per-language SDKs published to multiple package managers (one per consumer language), with the plugin executable published to an accessible location. Pre-publishing SDKs isn't strictly required — consumers can run [`pulumi package add`](/docs/iac/cli/commands/pulumi_package_add/) to generate an SDK locally from the package schema — but most executable packages pre-publish because, once you're already shipping a binary per release, publishing per-language SDKs is a natural extension. Pulumi Cloud customers can also publish to the Pulumi IDP Private Registry using [`pulumi package publish`](/docs/iac/cli/commands/pulumi_package_publish/).
 
 Consumers install the published SDK like any other Pulumi provider package. Pulumi automatically downloads and caches the plugin executable the first time the consuming program runs.
 
-For the authoring workflow, see [Build a provider](/docs/iac/guides/building-extending/providers/build-a-provider/).
+For guidance on how to group components into packages and repositories so versioning stays meaningful, see [Repository strategy for Pulumi packages](/docs/iac/guides/building-extending/packages/repository-strategy/) — the same strategy applies to source-based and executable-based plugin packages.
 
 ### Advantages and limitations
 
 - **No consumer runtime dependencies**: The plugin ships as a native executable, so consumers don't need Node.js, Python, a JVM, or a Go toolchain.
 - **Full package capabilities**: Can expose custom resources and functions alongside components. (A source-based plugin package in Go can also do this.)
 - **Go strongly recommended**: Providers are usually written in Go because [`pulumi-go-provider`](https://github.com/pulumi/pulumi-go-provider) infers the [schema](/docs/iac/guides/building-extending/packages/schema/) automatically; other languages require hand-authored schemas.
-- **CI/CD overhead**: Pre-publishing SDKs and the plugin executable requires a more involved release pipeline.
+- **CI/CD overhead**: Cross-compiling the plugin executable and (usually) pre-publishing SDKs requires a more involved release pipeline.
 - **Argument type limitations**: Same serialization limits as source-based plugin packages — see [Component arguments and type requirements](/docs/iac/guides/building-extending/components/build-a-component/#component-arguments-and-type-requirements).
 
 {{% notes type="info" %}}
@@ -109,5 +109,5 @@ Consuming an executable-based plugin package whose plugin is written in a non-Go
 | **Cross-language consumption** | No — limited to the authoring language | Yes — consume in any Pulumi language | Yes — consume in any Pulumi language |
 | **Pulumi Cloud IDP Private Registry support** | No | Yes | Yes |
 | **Packaging complexity** | Minimal — publish a native package | Low — `PulumiPlugin.yaml` plus an entry file | High — schema authoring, SDK generation, and executable publishing |
-| **Distribution** | Native package managers (npm, PyPI, etc.) | Git reference (via `pulumi package add`) or pre-built SDKs on native package managers | Pre-built SDKs on native package managers plus a published plugin executable |
+| **Distribution** | Native package managers (npm, PyPI, etc.) | Git reference (via `pulumi package add`) or pre-built SDKs on native package managers | Published plugin executable plus per-language SDKs (usually pre-published to npm, PyPI, etc.; can also be generated locally) |
 | **Consumer runtime dependencies** | n/a | Authoring language's runtime | None — plugin is a native executable |

--- a/content/docs/iac/guides/building-extending/packages/_index.md
+++ b/content/docs/iac/guides/building-extending/packages/_index.md
@@ -1,0 +1,70 @@
+---
+title_tag: "Pulumi Packages Guides"
+meta_desc: Pulumi packages let you author infrastructure abstractions and consume them in any Pulumi language via source-based or executable-based plugins.
+title: Pulumi Packages Guides
+h1: Pulumi Packages Guides
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+  iac:
+    name: Packages
+    identifier: iac-guides-packages
+    parent: iac-guides-building-extending
+    weight: 2
+---
+
+A [Pulumi package](/docs/iac/concepts/packages/) bundles components or a provider with a plugin so Pulumi can generate an SDK for any supported language. Package authors choose between two distribution models — source-based and executable-based — which differ in consumer runtime requirements, registry support, and publishing overhead.
+
+{{% notes type="info" %}}
+Native language packages (npm, PyPI, Go modules, etc.) are another option for sharing components within a single language — see [Packaging Components](/docs/iac/guides/building-extending/components/packaging-components/) for details.
+{{% /notes %}}
+
+## Package types
+
+### Source-based plugin package
+
+A Pulumi package distributed as source code. SDKs are usually generated locally by the Pulumi CLI when consumers run `pulumi package add` against a Git URL, a local path, or a `PulumiPlugin.yaml` in an existing repo — though you can also pre-publish per-language SDKs to native package registries if you prefer. The runtime requirements for consumers are the same as for any Pulumi program written in the authoring language: Node.js for TypeScript, Python for Python, a JVM for Java, and so on. Compiled Go and .NET components have no additional consumer runtime requirement.
+
+Choose this when:
+
+- You want multi-language consumption with the least authoring overhead.
+- Your consumers can reasonably install the authoring language's runtime.
+- You're publishing to the Pulumi IDP Private Registry, or to no registry at all (source-based packages work fine consumed directly from Git).
+
+See [Authoring a Source-Based Plugin Package](./source-based-plugin/) for the full workflow.
+
+### Executable-based plugin package
+
+A Pulumi package whose plugin is a pre-built executable, typically a Pulumi [provider](/docs/iac/concepts/providers/). The Pulumi CLI downloads the binary at `pulumi install` time from a `pluginDownloadURL` and runs it as a subprocess, so no authoring-language runtime is required on the consumer's machine. SDKs are usually pre-published to npm, PyPI, NuGet, Maven Central, and as a tagged Go module — consumers can still generate SDKs locally from the schema, but since you're already running a CI/CD pipeline to publish binaries, publishing the SDKs alongside is a natural extension.
+
+Pulumi only provides supported tooling for authoring executable plugins in Go (via [`pulumi-go-provider`](./pulumi-go-provider-sdk/)), and for practical purposes new executable plugins should be written in Go. Other languages are documented but require hand-authoring the schema and managing serialization details yourself.
+
+Choose this when:
+
+- You are publishing to the public [Pulumi Registry](/registry/).
+- You need to expose custom resources or provider functions from any authoring language.
+- You want zero consumer runtime dependencies and are willing to invest in cross-compilation and (usually) per-language SDK publishing.
+
+See [Authoring an Executable Plugin Package](./executable-plugin/) for the full workflow.
+
+## Comparison
+
+| | Source-based plugin package | Executable-based plugin package |
+|---|---|---|
+| Consumer runtime required | Authoring language | None |
+| Custom resources and functions | Go only via [`pulumi-go-provider`](./source-based-plugin/#package-contents-by-authoring-language) | Yes (all languages) |
+| Pulumi IDP Private Registry | Supported | Supported |
+| Public Pulumi Registry | Not supported today | Supported |
+| Pre-publishing SDKs | Optional (usually generated locally) | Typical (consumers can still generate locally) |
+| Publishing overhead | Low | High |
+| Iteration speed | Fast | Slower |
+
+## Guides in this section
+
+- [Authoring a Source-Based Plugin Package](./source-based-plugin/) — author a Pulumi package distributed as source and consumed via `pulumi package add`. Pulumi generates the SDK in the consumer's language on demand.
+- [Authoring an Executable Plugin Package](./executable-plugin/) — cross-compile a plugin binary, configure `pluginDownloadURL`, and publish per-language SDKs so the package runs on any consumer with no runtime dependency.
+- [Publishing a Package to the Pulumi Registry](./publishing-packages/) — publish to the public Pulumi Registry.
+- [Publishing Components from GitHub Actions](/docs/idp/guides/publishing-from-github-actions/) — publish to the Pulumi IDP Private Registry.
+- [Repository Strategy for Pulumi Packages](./repository-strategy/) — group components and providers across repositories and versions; applies to both source-based and executable-based packages.
+- [Local Packages](./local-packages/) — consume a package from a local path for iteration and monorepos.
+- [Pulumi Go Provider SDK](./pulumi-go-provider-sdk/) — build components, custom resources, and functions in Go.
+- [Schema Reference](./schema/) — Pulumi package schema for providers.

--- a/content/docs/iac/guides/building-extending/packages/executable-plugin.md
+++ b/content/docs/iac/guides/building-extending/packages/executable-plugin.md
@@ -1,0 +1,189 @@
+---
+title: Authoring an Executable Plugin Package
+meta_desc: How to author a Pulumi plugin package shipped as a pre-compiled binary. Covers binary naming, cross-compilation, pluginDownloadURL, and SDK publishing.
+menu:
+  iac:
+    parent: iac-guides-packages
+    weight: 20
+---
+
+An **executable-based plugin package** ships as a pre-compiled binary per operating system and architecture. The Pulumi CLI downloads the binary on demand from a URL embedded in the package schema and runs it as a subprocess — so consumers never need the authoring language's runtime installed. This is the model used by almost every package in the public [Pulumi Registry](/registry/) (AWS, GCP, EKS, etc.).
+
+{{% notes type="info" %}}
+The runtime-free guarantee assumes a fully self-contained binary. A framework-dependent .NET plugin (built without `--self-contained`) still requires consumers to have a compatible .NET runtime installed.
+{{% /notes %}}
+
+{{% notes type="info" %}}
+If you are looking to package and share components, a [source-based plugin package](./source-based-plugin/) is usually a better fit — see [Packaging Components](/docs/iac/guides/building-extending/components/packaging-components/) for the component-author overview. This guide covers the executable model, which applies when you are shipping custom resources, provider functions, or publishing to the public [Pulumi Registry](/registry/). See the [Pulumi Packages Guides](/docs/iac/guides/building-extending/packages/) index for the comparison against source-based packages.
+{{% /notes %}}
+
+## Binary naming and archive layout
+
+Every executable plugin follows a strict naming convention so the Pulumi CLI can locate and launch it.
+
+**Binary name:** `pulumi-resource-<package-name>` (on Windows, append `.exe`). The `resource` kind is Pulumi's internal term for component/provider plugins — always use `resource` for this kind of package. Other plugin kinds (`analyzer`, `language`, `converter`, `tool`) exist for different plugin classes and are not relevant here.
+
+**Archive name:** `pulumi-resource-<package-name>-v<version>-<os>-<arch>.tar.gz`
+
+- `<version>` is the plugin version without a leading `v` inside the archive, but the filename uses `v<version>`.
+- `<os>` is one of `darwin`, `linux`, `windows`.
+- `<arch>` is one of `amd64`, `arm64`.
+
+**Archive contents:** the binary sits at the archive root — no leading directory.
+
+Concrete example for an EKS-style package at version 3.0.0:
+
+```text
+pulumi-resource-eks-v3.0.0-linux-amd64.tar.gz
+└── pulumi-resource-eks   # single binary serves every component in the package
+                          # (e.g. Cluster, ManagedNodeGroup, NodeGroup, VpcCni, ...)
+```
+
+You'll produce one archive per OS/arch target.
+
+## Cross-compilation
+
+Pulumi's own providers ship binaries for six targets: `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`, `windows/arm64`. Match this matrix unless you have a reason to ship a subset.
+
+Go is the practical choice for executable plugins: Pulumi's supported tooling for authoring them is Go-only (via [`pulumi-go-provider`](/docs/iac/guides/building-extending/packages/pulumi-go-provider-sdk/), which also infers the schema). Other languages are documented but require hand-authoring the schema. For Go, cross-compilation is a matter of setting `GOOS` and `GOARCH`:
+
+```bash
+mkdir -p dist
+for os in linux darwin windows; do
+  for arch in amd64 arm64; do
+    ext=""
+    [ "$os" = "windows" ] && ext=".exe"
+    GOOS=$os GOARCH=$arch go build \
+      -o "dist/pulumi-resource-<name>$ext" \
+      ./provider/cmd/pulumi-resource-<name>
+    tar -czf "dist/pulumi-resource-<name>-v<version>-$os-$arch.tar.gz" \
+      -C dist "pulumi-resource-<name>$ext"
+  done
+done
+```
+
+For .NET, use `dotnet publish -c Release -r <rid> --self-contained` with one invocation per [runtime identifier](https://learn.microsoft.com/dotnet/core/rid-catalog) (`linux-x64`, `linux-arm64`, `osx-x64`, `osx-arm64`, `win-x64`, `win-arm64`), then package the output.
+
+Node.js and Python plugins are typically not cross-compiled — tools like `pkg` can bundle a Node.js binary, but the workflow is uncommon in practice. For most executable plugins, Go is the pragmatic choice; .NET is the next most common.
+
+## `pluginDownloadURL`
+
+`pluginDownloadURL` is a field in the package [schema](./schema/) that tells the Pulumi CLI where to fetch the plugin binary. The CLI constructs the full archive URL by interpolating variables and appending the expected archive name:
+
+```text
+${pluginDownloadURL}/pulumi-${kind}-${name}-v${version}-${os}-${arch}.tar.gz
+```
+
+The CLI interpolates four variables into `pluginDownloadURL` itself if they appear there:
+
+- `${NAME}` — the package name.
+- `${VERSION}` — the plugin version (without the leading `v`).
+- `${OS}` — the consumer's OS (typically `darwin`, `linux`, or `windows`).
+- `${ARCH}` — the consumer's architecture (typically `amd64` or `arm64`).
+
+Typically you won't need the interpolation variables for GitHub or GitLab hosting (those have dedicated URL forms below); they are mostly useful for custom HTTP hosts whose layouts don't match the default archive-naming convention.
+
+### Hosting options
+
+Set `pluginDownloadURL` in your schema to one of the following:
+
+**GitHub Releases** (most common; zero infrastructure): since Pulumi v3.35.3, the CLI understands a special URL form that resolves to release assets.
+
+```text
+github://api.github.com/<org>[/<repo>]
+```
+
+If the `<repo>` segment is omitted, the CLI defaults to `pulumi-<package-name>`. Upload your `.tar.gz` archives as release assets on a tag matching your plugin version.
+
+**GitLab Releases** (since Pulumi v3.56.0):
+
+```text
+gitlab://gitlab.com/<project_id>
+```
+
+`<project_id>` is the numeric project ID shown below the project name on the GitLab project page.
+
+**Custom S3, HTTP, or CDN:** set `pluginDownloadURL` to a plain URL. You own the layout — the archive must be reachable at `${pluginDownloadURL}/pulumi-resource-<name>-v<version>-<os>-<arch>.tar.gz`, or you must supply the interpolation variables in the URL to reshape the path.
+
+If `pluginDownloadURL` is omitted, the Pulumi CLI falls back to `get.pulumi.com`. That fallback is meant for Pulumi-hosted providers; third-party authors should always set an explicit value.
+
+## Building the release pipeline
+
+Cross-compiling on tag push, uploading archives, generating SDKs, and publishing them to npm, PyPI, NuGet, and Maven is a lot of moving parts. Pulumi publishes template repositories that solve all of it end-to-end.
+
+### Start from a boilerplate
+
+Fork the template that matches your authoring model:
+
+| Repository | Use when |
+|---|---|
+| [`pulumi/pulumi-provider-boilerplate`](https://github.com/pulumi/pulumi-provider-boilerplate) | Authoring a native Pulumi provider with custom resources, typically in Go |
+| [`pulumi/pulumi-tf-provider-boilerplate`](https://github.com/pulumi/pulumi-tf-provider-boilerplate) | Bridging a Terraform provider |
+
+For a Go component package, author a [source-based plugin](./source-based-plugin/) with [`pulumi-go-provider`](./pulumi-go-provider-sdk/) instead, or start from `pulumi/pulumi-provider-boilerplate` if you need full executable-plugin behavior alongside components.
+
+### The general release pipeline
+
+If the boilerplates don't fit, the common pattern they implement has four parts you can reproduce yourself:
+
+1. **Cross-compilation.** A Makefile target or CI matrix job produces one `.tar.gz` per OS/arch target — the archive layout described in [Binary naming and archive layout](#binary-naming-and-archive-layout).
+1. **Release workflow.** A tag-triggered workflow (typically on `v*.*.*`) runs the matrix build and uploads archives as GitHub Release assets (so `pluginDownloadURL: github://api.github.com/<org>` resolves to them), then generates and publishes per-language SDKs.
+1. **SDK publishing.** The composite action [`pulumi/pulumi-package-publisher`](https://github.com/pulumi/pulumi-package-publisher) handles npm, PyPI, NuGet, and Maven Central in a single step. Select languages with the `sdk:` input (e.g., `sdk: "nodejs,python"`).
+1. **Go module tag.** Push a Go module tag so consumers can `go get` the SDK — the boilerplates carry the canonical layout.
+
+Pulumi-hosted providers additionally upload archives to `s3://get.pulumi.com/releases/plugins/` (the CLI's default fallback when `pluginDownloadURL` is omitted). Third-party providers do not need and cannot implement this step — point `pluginDownloadURL` at your own GitHub, GitLab, or S3 location instead.
+
+## Publishing SDKs
+
+The binary plugin is what removes the consumer runtime dependency — not the SDK. Consumers can still run [`pulumi package gen-sdk`](/docs/iac/cli/commands/pulumi_package_gen-sdk/) against your schema to generate a local SDK, the same as with a [source-based plugin package](./source-based-plugin/). Once you've committed to publishing a binary per release, though, publishing per-language SDKs to npm, PyPI, NuGet, Maven Central, and as a tagged Go module is a natural extension — and most packages in the public Pulumi Registry do both.
+
+A typical release pipeline for each tagged release looks like this:
+
+1. Push a `vX.Y.Z` tag.
+1. Cross-compile the binary matrix and upload archives to GitHub Releases (or your chosen host).
+1. Run `pulumi package gen-sdk` once per target language.
+1. Publish SDKs via [`pulumi/pulumi-package-publisher`](https://github.com/pulumi/pulumi-package-publisher) — it handles npm, PyPI, NuGet, and Maven Central.
+1. Push a Go module tag so consumers can `go get` the Go SDK.
+
+## Trade-offs vs. source-based plugins
+
+| | Source-based plugin | Executable plugin |
+|---|---|---|
+| Consumer runtime required | Authoring language | None |
+| Publishing overhead | Low | High |
+| Pulumi IDP Private Registry | Supported | Supported |
+| Public Pulumi Registry | Not supported today | Supported |
+| Iteration speed | Fast | Slower |
+
+For the full comparison against source-based plugin packages, see the [Pulumi Packages Guides](/docs/iac/guides/building-extending/packages/) index.
+
+## Appendix: How it works at runtime
+
+At `pulumi install` or `pulumi up` time, the Pulumi CLI resolves each package's plugin, downloads the matching binary archive for the consumer's OS and architecture, extracts it into the plugin cache, and launches it as a subprocess over gRPC. The binary runs independently of the consumer's language runtime; communication happens only through the Pulumi RPC boundary.
+
+```mermaid
+sequenceDiagram
+    participant P as Consumer program
+    participant C as Pulumi CLI
+    participant H as Plugin host
+    participant B as Binary host (GitHub / GitLab / S3)
+    P->>C: pulumi up
+    C->>C: Resolve plugin from schema (name, version, pluginDownloadURL)
+    alt Plugin not cached
+        C->>B: GET pulumi-resource-<name>-vX.Y.Z-<os>-<arch>.tar.gz
+        B-->>C: archive
+        C->>C: Extract to ~/.pulumi/plugins/
+    end
+    C->>H: Launch pulumi-resource-<name>
+    H-->>C: gRPC ready
+    C->>H: Register / Check / Diff / Create / Update / Delete
+    H-->>C: results
+```
+
+## Additional resources
+
+- [Pulumi Packages Guides](/docs/iac/guides/building-extending/packages/)
+- [Authoring a Source-Based Plugin Package](./source-based-plugin/)
+- [Publishing a Package to the Pulumi Registry](./publishing-packages/)
+- [Schema Reference](./schema/)
+- [Pulumi Go Provider SDK](./pulumi-go-provider-sdk/)

--- a/content/docs/iac/guides/building-extending/packages/local-packages.md
+++ b/content/docs/iac/guides/building-extending/packages/local-packages.md
@@ -4,7 +4,7 @@ meta_desc: This page provides an overview of working with locally generated Pulu
 menu:
   iac:
     parent: iac-guides-packages
-    weight: 65
+    weight: 50
 aliases:
   - /docs/using-pulumi/pulumi-packages/local-packages/
   - /docs/iac/build-with-pulumi/local-packages/

--- a/content/docs/iac/guides/building-extending/packages/publishing-packages.md
+++ b/content/docs/iac/guides/building-extending/packages/publishing-packages.md
@@ -1,14 +1,14 @@
 ---
-title_tag: "Publishing Packages"
-meta_desc: "Learn how to publish Pulumi packages to your organization's private registry or the public Pulumi Registry."
-title: Publishing packages
-h1: Publishing Pulumi packages
+title_tag: "Publishing to the Pulumi Registry"
+meta_desc: "Learn how to publish a Pulumi package to the public Pulumi Registry so it's discoverable by the Pulumi community."
+title: Publishing to the Pulumi Registry
+h1: Publishing to the Pulumi Registry
 meta_image: /images/docs/meta-images/docs-meta.png
 menu:
     iac:
-        name: Publishing packages
+        name: Publishing to the Pulumi Registry
         parent: iac-guides-packages
-        weight: 60
+        weight: 30
 aliases:
 - /docs/guides/pulumi-packages/how-to-author/
 - /docs/using-pulumi/pulumi-packages/contribute-to-pulumi-registry/
@@ -21,46 +21,13 @@ aliases:
 - /docs/iac/build-with-pulumi/publishing-packages/
 ---
 
-Pulumi packages can be published to two different registries depending on your use case:
+This page covers publishing a [Pulumi package](/docs/iac/concepts/packages/) to the public [Pulumi Registry](/registry/) so it's discoverable by the Pulumi community.
 
-- **Your organization's [Private Registry](/docs/idp/concepts/private-registry/)** in Pulumi Cloud, for components and providers used within your organization.
-- **The public [Pulumi Registry](/registry/)**, for open-source packages shared with the Pulumi community.
+{{% notes type="info" %}}
+Publishing to your organization's **[Pulumi IDP Private Registry](/docs/idp/concepts/private-registry/)**? Use the [`pulumi package publish`](/docs/iac/cli/commands/pulumi_package_publish/) command — see [Publishing Components from GitHub Actions](/docs/idp/guides/publishing-from-github-actions/) for the full workflow. This page covers the public Pulumi Registry only.
+{{% /notes %}}
 
-## Publish to your organization's private registry
-
-Pulumi Cloud's [Private Registry](/docs/idp/concepts/private-registry/) lets platform teams publish components for discovery and reuse across their organization. Published components appear in a browsable gallery with auto-generated API documentation.
-
-### Before you begin
-
-1. You need a [Pulumi Cloud](https://app.pulumi.com) account on the Enterprise or Business Critical plan.
-1. Your component must be pushed to a GitHub or GitLab repository that Pulumi can access. Private repositories are supported.
-1. If you haven't built a component yet, see [Build a Component](/docs/iac/guides/building-extending/components/build-a-component/). To choose the right packaging approach for your needs, see [Packaging Components](/docs/iac/guides/building-extending/components/packaging-components/). For guidance on how to group multiple components into packages and repositories, see [Repository strategy for Pulumi packages](/docs/iac/guides/building-extending/packages/repository-strategy/).
-
-### Publish your component
-
-Use the [`pulumi package publish`](/docs/iac/cli/commands/pulumi_package_publish/) command to publish a component to your organization's private registry:
-
-```bash
-pulumi package publish github.com/<org>/<component-name>
-```
-
-To publish a specific version, tag your repository and specify the version:
-
-```bash
-git tag v1.0.0
-git push origin v1.0.0
-pulumi package publish github.com/<org>/<component-name>@1.0.0
-```
-
-### Learn more
-
-For the full details on component versioning, README requirements, API docs annotations, authentication with private repositories, and more, see the [Private Registry](/docs/idp/concepts/private-registry/) documentation.
-
-To set up automated publishing via CI/CD, see [Publishing from GitHub Actions](/docs/idp/guides/publishing-from-github-actions/).
-
-## Publish to the public Pulumi Registry
-
-This section covers how to publish a [Pulumi Package](/docs/iac/concepts/packages) to the public [Pulumi Registry](/registry). You can publish the following types of packages:
+You can publish the following types of packages to the public Pulumi Registry:
 
 - A [component](/docs/iac/concepts/components) or related group of components
 - A custom provider where you define the CRUD operations for each resource type
@@ -70,7 +37,7 @@ This section covers how to publish a [Pulumi Package](/docs/iac/concepts/package
 If you are a cloud or SaaS provider interested in publishing a Pulumi provider or component, please [reach out to our partners team](/contact).
 {{% /notes %}}
 
-### Prerequisites
+## Prerequisites
 
 {{% notes type="info" %}}
 This guide assumes you're using GitHub to host your package's source code and GitHub Actions to publish various parts of your package.
@@ -81,11 +48,11 @@ This guide assumes you're using GitHub to host your package's source code and Gi
 - Pulumi Packages are multi-language: you can write your package once in either Go, Python, or TypeScript/JavaScript and then make it available to all Pulumi users, even if they use another language. To develop them, you need to have Git, Go, .NET, Python, and TypeScript installed on your system.
 - To follow the whole guide, you need a GitHub account. However, using GitHub is not a requirement; you may still find this guide useful even if you use another system to store your source code.
 
-### Create a repository and author your package
+## Create a repository and author your package
 
 To get started, create a repository for your Pulumi Package. We recommend hosting your Pulumi Package in a public repository on GitHub. We also recommend following the naming conventions below to help the community find the source code for your packages.
 
-#### Select a template
+### Select a template
 
 We've created some template repositories for you to use as a starting point for your package. These templates are for **provider-based packages**. If you are building a cross-language component (recommended for most platform teams), see [Packaging Components](/docs/iac/guides/building-extending/components/packaging-components/) for the recommended approach.
 
@@ -98,7 +65,7 @@ Click the link for the boilerplate repository template that you want to use, the
 If you need access to a Terraform provider, but don't need the full customization of a published provider, the ["Any Terraform Provider" Pulumi Provider](/registry/packages/terraform-provider) can provide instant access via locally generating SDKs.
 {{% /notes %}}
 
-#### Name your provider and repository
+### Name your provider and repository
 
 When you publish to the [Pulumi Package Registry](https://www.pulumi.com/registry/), you will need to pick a unique name. This is normally named after the cloud provider or service the provider configures.
 
@@ -107,15 +74,15 @@ Your repository name should start with `pulumi-` followed by the name of your pr
 - If you're bridging a Terraform provider, re-use the Terraform provider's name - replacing `terraform-provider-` with `pulumi-` e.g. use `pulumi-auth0` for bridging `terraform-provider-auth0`.
 - If you're building a component on top of an existing provider, consider using the provider name followed by the component name. For example, if building an API Gateway component using the AWS provider, name your project `pulumi-aws-apigateway`.
 
-### Author your resources or components
+## Author your resources or components
 
 See the instructions in your new repository's `README.md` file for specific instructions on how to author your package. We also have guides you can follow for building [components](/docs/iac/concepts/resources/components/) and [providers](/docs/iac/concepts/providers/) without the template repos.
 
-### Write documentation
+## Write documentation
 
 We recommend writing documentation to help others in the Pulumi community use your package. In your repository, there should be a `docs/` folder containing markdown files (the templates include a few suggested pages). The files should correspond to the various tabs on a package page in Pulumi Registry (like the [Azure Native](/registry/packages/azure-native/) package). Use the guidance in the following sections to author content in these pages.
 
-#### Overview, installation, & configuration
+### Overview, installation, & configuration
 
 Specifically, you should author a few pages:
 
@@ -126,7 +93,7 @@ Specifically, you should author a few pages:
 We recommend keeping the contents of `README.md` and `_index.md` similar or the same, save for the YAML metadata/front-matter that's in `_index.md`.
 {{% /notes %}}
 
-#### Package metadata
+### Package metadata
 
 Metadata for your package is generated from the [`schema.json`](/docs/iac/using-pulumi/extending-pulumi/schema) in your repository. To make sure your package looks great in the Pulumi Registry, don't forget to add metadata like:
 
@@ -138,74 +105,29 @@ Metadata for your package is generated from the [`schema.json`](/docs/iac/using-
   - `category/CATEGORY`: replace `CATEGORY` with one of `cloud`, `database`, `infrastructure`, `monitoring`, `network`, `utility`, `versioncontrol`
   - `kind/KIND`: replace `KIND` with one of `native`, `component`
     - Note: don't set a kind if you're bridging a Terraform provider
-- `pluginDownloadURL`: a web-accessible URL that contains the compiled binary plugin associated with your package; for more information see [Publish your package](#publish-your-package)
+- `pluginDownloadURL`: a web-accessible URL that contains the compiled plugin binary associated with your package. See [Authoring an Executable Plugin Package](./executable-plugin/#plugindownloadurl) for the URL format, hosting options (GitHub Releases, GitLab Releases, custom HTTP), and interpolation variables.
 
-{{% notes %}}
-Pulumi will interpolate `${VERSION}`, `${OS}` and `${ARCH}` with their respective values if found in `pluginDownloadURL`.
-{{% /notes %}}
-
-#### API docs
+### API docs
 
 API docs for your package are automatically generated from the `schema.json` in your repository. Many Pulumi users learn to use a Pulumi Package via the API docs, since they appear automatically in many IDEs' auto-complete and inline documentation features, like Visual Studio Code's IntelliSense feature. Investing in API docs for your package is one of the best ways to improve its usability. Check out the [`pulumi-eks` schema](https://github.com/pulumi/pulumi-eks/blob/master/provider/cmd/pulumi-resource-eks/schema.json) to see how it translates to the [Pulumi Registry](/registry/packages/eks/api-docs/) for an example of great API docs.
 
-#### How-to guides
+### How-to guides
 
 You can also create how-to guides for your packages by contributing them to the [`pulumi/examples`](https://github.com/pulumi/examples) repository on GitHub.
 
-### Publish your package
+## Publish your package
 
 Once you've authored and tested your package locally, you can publish it to make it available to the Pulumi community. You must publish several artifacts:
 
-- The npm, NuGet, Java, and Python SDK packages to the [npm Registry](https://npmjs.com), the [NuGet Gallery](https://nuget.org), [Maven Central](https://central.sonatype.com) and the [Python Package Index](https://pypi.org)
-  - If your package is hosted on GitHub, you may choose to use our [custom Action for publishing Pulumi packages](https://github.com/pulumi/pulumi-package-publisher)
-- The Go module to your Git repository, by adding a tag, which we'll explain in the sections below
-- The binary Pulumi resource provider plugin to a binary hosting provider of your choice
-- The [package documentation](#publish-the-documentation) - overview, installation & configuration, API docs, and how-to guides to [Pulumi Registry](/registry/)
+- The npm, NuGet, Java, and Python SDK packages to the [npm Registry](https://npmjs.com), the [NuGet Gallery](https://nuget.org), [Maven Central](https://central.sonatype.com) and the [Python Package Index](https://pypi.org).
+  - If your package is hosted on GitHub, you may choose to use our [custom Action for publishing Pulumi packages](https://github.com/pulumi/pulumi-package-publisher).
+- The Go module to your Git repository, by adding a tag.
+- The plugin binary to a host of your choice (GitHub Releases, GitLab Releases, or a custom HTTP endpoint).
+- The [package documentation](#publish-the-documentation) — overview, installation & configuration, API docs, and how-to guides to [Pulumi Registry](/registry/).
 
-The URL used to download a plugin is derived from `pluginDownloadURL`, as specified in the schema. Pulumi expects to find a plugin at
+For how to cross-compile the plugin binary, the archive naming convention the CLI expects, and the supported `pluginDownloadURL` forms, see [Authoring an Executable Plugin Package](./executable-plugin/). That guide also covers the canonical release pipeline used by Pulumi's own providers, including the [`pulumi/pulumi-package-publisher`](https://github.com/pulumi/pulumi-package-publisher) GitHub Action for publishing SDKs.
 
-```
-${pluginDownloadURL}/pulumi-${kind}-${name}-v${version}-${os}-${arch}.tar.gz
-```
-
-- `name`: the name field specified in the schema
-- `version`: the version field specified in the schema
-- `kind`: the kind specified in schema, probably `resource`
-- `os`: the target operating system (one of `darwin`, `linux`, `windows`)
-- `arch`: the target system architecture (one of `amd64`, `arm64`)
-
-Pulumi packages consist of SDKs, as well as a binary to facilitate the actual task (creating cloud resources, etc.). Package
-managers (npm, NuGet, Pip, GitHub) host the SDKs, but we need to know where the plugin is hosted. When a package embeds its
-`pluginDownloadURL`, we can automatically fetch the plugin. This means that `pulumi up` just works, and there is no need to run
-`pulumi plugin install ${NAME} ${VERSION} --server ${pluginDownloadURL}`. If `pluginDownloadURL` is not supplied, then the Pulumi
-CLI assumes the plugin is hosted at `get.pulumi.com`.
-
-#### Support for GitHub releases
-
-Since [release 3.35.3](https://github.com/pulumi/pulumi/releases/tag/v3.35.3), Pulumi understands a special form of `pluginDownloadURL` to download plugins via GitHub releases
-
-```
-github://${github api host}/{organization}[/{repository}]
-```
-
-- `github api host`: the address of a GitHub API, for `github.com` this is `api.github.com`
-- `organization`: the GitHub organization to use
-- `repository`: the GitHub repository to use, this defaults to `pulumi-${package name}`
-
-For example the [Pulumiverse Astra](https://github.com/pulumiverse/pulumi-astra) package would specify `github://api.github.com/pulumiverse`.
-
-#### Support for Gitlab releases
-
-Since [release 3.56.0](https://github.com/pulumi/pulumi/releases/tag/v3.56.0), Pulumi understands a special form of `pluginDownloadURL` to download plugins via Gitlab releases
-
-```
-gitlab://${gitlab api host}/{<project_id>}
-```
-
-- `gitlab api host`: the address of a Gitlab API, for Gitlab SaaS this is `gitlab.com`
-- `project_id`: the Gitlab project ID to use. The project ID can be found right below the project name on the project page.
-
-### Publish the documentation
+## Publish the documentation
 
 All package documentation in the Pulumi Registry is published via the [`pulumi/registry` repository on GitHub](https://github.com/pulumi/registry). To publish your package to the Pulumi Registry:
 

--- a/content/docs/iac/guides/building-extending/packages/pulumi-go-provider-sdk.md
+++ b/content/docs/iac/guides/building-extending/packages/pulumi-go-provider-sdk.md
@@ -8,7 +8,7 @@ menu:
     iac:
         name: Pulumi Go Provider SDK
         parent: iac-guides-packages
-        weight: 68
+        weight: 60
 aliases:
 - /docs/iac/using-pulumi/extending-pulumi/pulumi-provider-sdk/
 - /docs/iac/extending-pulumi/pulumi-provider-sdk/

--- a/content/docs/iac/guides/building-extending/packages/repository-strategy.md
+++ b/content/docs/iac/guides/building-extending/packages/repository-strategy.md
@@ -5,7 +5,7 @@ menu:
   iac:
     name: Repository Strategy
     parent: iac-guides-packages
-    weight: 61
+    weight: 40
 ---
 
 Effectively developing and managing [Pulumi packages](/docs/iac/concepts/packages/) is key to building your organization's platform with Pulumi. A package is the unit of versioning and distribution; the [components](/docs/iac/concepts/components/) inside it inherit the package's version. This guide describes Pulumi's recommended strategies for structuring the Git repositories you use to publish packages. Following these practices improves the reliability, maintainability, and delivery speed of the packages your organization builds and consumes.

--- a/content/docs/iac/guides/building-extending/packages/source-based-plugin.md
+++ b/content/docs/iac/guides/building-extending/packages/source-based-plugin.md
@@ -4,15 +4,15 @@ meta_desc: How to author a Pulumi plugin package distributed as source code in T
 menu:
   iac:
     parent: iac-guides-packages
-    weight: 60
+    weight: 10
 ---
 
 A **source-based plugin package** is a Pulumi plugin package distributed as source code rather than a pre-built executable. When a consumer runs `pulumi package add` against your repository or a local path, Pulumi introspects the package and generates an SDK in the consumer's language.
 
-Source-based plugin packages are one of three ways to distribute a component. For the comparison against native language packages and executable-based plugin packages, see [Packaging Components](/docs/iac/guides/building-extending/components/packaging-components/).
+Source-based plugin packages are the recommended way to package and share [components](/docs/iac/concepts/components/) — they enable multi-language consumption with minimal authoring overhead. For a detailed comparison against the other ways to distribute components, see [Packaging Components](/docs/iac/guides/building-extending/components/packaging-components/).
 
 {{< notes type="info" >}}
-Source-based packages most commonly contain [components](/docs/iac/concepts/components/) — the rest of this guide focuses on that case, since it's the typical use and works across all supported authoring languages. When authoring in Go via [`pulumi-go-provider`](https://github.com/pulumi/pulumi-go-provider), a source-based package can also expose [custom resources](/docs/iac/concepts/resources/) and [functions](/docs/iac/concepts/functions/) (invokes); see [Package contents by authoring language](#package-contents-by-authoring-language) below.
+Source-based packages most commonly contain components, and the rest of this guide focuses on that case. When authoring in Go via [`pulumi-go-provider`](https://github.com/pulumi/pulumi-go-provider), a source-based package can also expose [custom resources](/docs/iac/concepts/resources/) and [functions](/docs/iac/concepts/functions/) (invokes); see [Package contents by authoring language](#package-contents-by-authoring-language). For custom resources or functions in other languages, or for publishing to the public [Pulumi Registry](/registry/), author an [executable-based plugin package](./executable-plugin/) instead.
 {{< /notes >}}
 
 The key wins of the source-based model are:


### PR DESCRIPTION
Benchmark fixture for S34 cross-session comparison. Upstream: pulumi/docs#18599. (Reopened with strict squash-tree base/head pattern after first attempt produced wrong diff.)