### PR TITLE
[bench-S41] feat(what-is): add breadcrumb and article metadata to page header

### DIFF
--- a/layouts/partials/schema/collectors/breadcrumb-entity.html
+++ b/layouts/partials/schema/collectors/breadcrumb-entity.html
@@ -3,17 +3,28 @@
 {{ $breadcrumbs := slice }}
 {{ $position := 0 }}
 
-{{/* Home is always the first item */}}
-{{ $position = add $position 1 }}
-{{ $breadcrumbs = $breadcrumbs | append (dict
-  "@type" "ListItem"
-  "position" $position
-  "name" "Home"
-  "item" "https://www.pulumi.com"
-) }}
+{{/* Home is the first item for most page types, but skipped for what-is to match visible breadcrumb */}}
+{{ if ne .Type "what-is" }}
+  {{ $position = add $position 1 }}
+  {{ $breadcrumbs = $breadcrumbs | append (dict
+    "@type" "ListItem"
+    "position" $position
+    "name" "Home"
+    "item" "https://www.pulumi.com"
+  ) }}
+{{ end }}
 
 {{/* Process parent sections */}}
-{{ if eq .Type "blog" }}
+{{ if eq .Type "what-is" }}
+  {{ $position = add $position 1 }}
+  {{ $breadcrumbs = $breadcrumbs | append (dict
+    "@type" "ListItem"
+    "position" $position
+    "name" "What Is"
+    "item" "https://www.pulumi.com/what-is/"
+  ) }}
+
+{{ else if eq .Type "blog" }}
   {{ $position = add $position 1 }}
   {{ $breadcrumbs = $breadcrumbs | append (dict
     "@type" "ListItem"
@@ -139,12 +150,12 @@
   ) }}
 {{ end }}
 
-{{/* Add current page (without URL for last item) */}}
+{{/* Add current page (without URL for last item). Prefer page_title so the schema matches what readers see in the visible breadcrumb. */}}
 {{ $position = add $position 1 }}
 {{ $breadcrumbs = $breadcrumbs | append (dict
   "@type" "ListItem"
   "position" $position
-  "name" .Title
+  "name" (or .Params.page_title .Title)
 ) }}
 
 {{/* Return breadcrumb entity */}}

--- a/layouts/partials/schema/collectors/main-entity.html
+++ b/layouts/partials/schema/collectors/main-entity.html
@@ -48,14 +48,8 @@
       {{ end }}
 
     {{ else if eq .Type "what-is" }}
-      {{/* What-is pages: try FAQ first (if they have questions), fallback to Article */}}
-      {{ $faqEntity := partial "schema/collectors/faq-entity.html" . }}
-      {{ if $faqEntity }}
-        {{ $entity = $faqEntity }}
-      {{ else }}
-        {{/* No questions found - treat as educational article */}}
-        {{ $entity = partial "schema/collectors/article-entity.html" . }}
-      {{ end }}
+      {{/* What-is pages always emit Article schema so dateModified and timeRequired are present for SERP */}}
+      {{ $entity = partial "schema/collectors/article-entity.html" . }}
 
     {{ else if eq .Type "docs" }}
       {{/* Documentation pages get TechArticle schema */}}

--- a/layouts/what-is/single.html
+++ b/layouts/what-is/single.html
@@ -1,5 +1,42 @@
 {{ define "hero" }}
-{{ partial "hero" (dict "title" .Params.page_title "small_title" "true") }}
+{{/* Use the same word-count source as the schema collector so visible "X min read" matches JSON-LD timeRequired. */}}
+{{ $wordCount := .Content | plainify | countwords }}
+{{ if not $wordCount }}{{ $wordCount = 500 }}{{ end }}
+{{ $readTime := div $wordCount 200 }}
+{{ if lt $readTime 1 }}{{ $readTime = 1 }}{{ end }}
+
+{{/* Only show the "Updated" line when we have a real source of truth — never fall back to now, which would churn each build. */}}
+{{ $modifiedDate := "" }}
+{{ if and .Lastmod (ne (.Lastmod.Format "2006-01-02") "0001-01-01") }}
+    {{ $modifiedDate = .Lastmod }}
+{{ else if and .GitInfo .GitInfo.AuthorDate }}
+    {{ $modifiedDate = .GitInfo.AuthorDate }}
+{{ end }}
+<header class="page-hero">
+    <div class="container mx-auto px-6 lg:px-0">
+        <nav aria-label="Breadcrumb" class="max-w-4xl mx-auto mb-6">
+            <ol class="flex flex-wrap items-center gap-2 text-sm text-gray-600">
+                <li><a class="hover:text-violet-700" href="/what-is/">What Is</a></li>
+                <li aria-hidden="true" class="text-gray-400">/</li>
+                <li aria-current="page" class="text-gray-900 font-medium">{{ .Params.page_title | safeHTML }}</li>
+            </ol>
+        </nav>
+        <div class="page-hero-title">
+            <h1 class="small-title">
+                <span><span data-text="{{ .Params.page_title }}">{{ .Params.page_title | safeHTML }}</span></span>
+            </h1>
+        </div>
+        <div class="max-w-4xl mx-auto mt-6 flex flex-wrap items-center justify-center gap-3 text-sm text-gray-600">
+            {{ with $modifiedDate }}
+                <time datetime="{{ .Format "2006-01-02T15:04:05Z07:00" }}">
+                    Updated {{ .Format "January 2, 2006" }}
+                </time>
+                <span aria-hidden="true">·</span>
+            {{ end }}
+            <span>{{ $readTime }} min read</span>
+        </div>
+    </div>
+</header>
 {{ end }}
 
 {{ define "main" }}


### PR DESCRIPTION
Fixture for benchmarking the docs-review pipeline; mirrors pulumi/docs#18874. Do not merge.