### PR TITLE
[deployments] Add execution environment guide for custom executor images

### DIFF
--- a/content/docs/administration/self-hosting/components/api.md
+++ b/content/docs/administration/self-hosting/components/api.md
@@ -470,7 +470,7 @@ scrape_configs:
 In order to enable [Pulumi Deployments](/docs/pulumi-cloud/deployments), the following must be configured:
 
 * `PULUMI_SERVICE_METADATA_BLOB_STORAGE_ENDPOINT` or `PULUMI_LOCAL_OBJECTS` [object storage](#object-storage)
-* [Customer-Managed Workflow Runners](/docs/deployments/deployments/customer-managed-agents/) - You also need to update the `pulumi-workflow-agent.yaml` [configuration file](/docs/deployments/deployments/customer-managed-agents/#configuration-reference) by setting `service_url` to `<PULUMI_API_DOMAIN>`. Example:
+* [Customer-Managed Workflow Runners](/docs/deployments/deployments/runs/customer-managed-agents/) - You also need to update the `pulumi-workflow-agent.yaml` [configuration file](/docs/deployments/deployments/runs/customer-managed-agents/#configuration-reference) by setting `service_url` to `<PULUMI_API_DOMAIN>`. Example:
 
     ```yaml
     token: pul-d2d2….

--- a/content/docs/administration/self-hosting/components/deployments.md
+++ b/content/docs/administration/self-hosting/components/deployments.md
@@ -22,7 +22,7 @@ Self-hosting is only available with **Pulumi Business Critical**. If you would l
 To manage your state with a self-managed backend, such as a cloud storage bucket, see [State and Backends](/docs/concepts/state/).
 {{% /notes %}}
 
-[Pulumi Deployments](/docs/deployments/deployments/) is fully supported in Kubernetes-managed self-hosted environments. If you're using Kubernetes to manage your self-hosted Pulumi Cloud installation, you can enable Pulumi Deployments features by configuring a Kubernetes-native workflow runner pool in Pulumi Cloud and installing one or more [customer-managed workflow runners](/docs/deployments/deployments/customer-managed-agents/) into your installation's Kubernetes cluster. In addition to deployments, customer-managed workflow runners also support [Insights](/docs/insights/) discovery scans and [policy evaluations](/docs/using-pulumi/crossguard/).
+[Pulumi Deployments](/docs/deployments/deployments/) is fully supported in Kubernetes-managed self-hosted environments. If you're using Kubernetes to manage your self-hosted Pulumi Cloud installation, you can enable Pulumi Deployments features by configuring a Kubernetes-native workflow runner pool in Pulumi Cloud and installing one or more [customer-managed workflow runners](/docs/deployments/deployments/runs/customer-managed-agents/) into your installation's Kubernetes cluster. In addition to deployments, customer-managed workflow runners also support [Insights](/docs/insights/) discovery scans and [policy evaluations](/docs/using-pulumi/crossguard/).
 
 To do so, follow these steps:
 

--- a/content/docs/deployments/deployments/_index.md
+++ b/content/docs/deployments/deployments/_index.md
@@ -35,7 +35,7 @@ Pulumi Deployments is a managed CI/CD platform purpose-built for infrastructure 
 - **Drift Detection**: [Automatically detect](/docs/deployments/deployments/drift) when your infrastructure differs from its desired state.
 - **Scheduled Operations**: Run any Pulumi operation (up/preview/refresh) on a [schedule](/docs/deployments/deployments/schedules).
 - **Temporary Infrastructure**: Automatically tear down development or testing environments with [TTL stacks](/docs/deployments/deployments/ttl).
-- **Custom Compute**: Run Pulumi operations, [Insights](/docs/insights/) discovery scans, and [policy evaluations](/docs/using-pulumi/crossguard/) on your own infrastructure with [customer-managed workflow runners](/docs/deployments/deployments/customer-managed-agents).
+- **Custom Compute**: Run Pulumi operations, [Insights](/docs/insights/) discovery scans, and [policy evaluations](/docs/using-pulumi/crossguard/) on your own infrastructure with [customer-managed workflow runners](/docs/deployments/deployments/runs/customer-managed-agents).
 
 ### Platform engineering features
 

--- a/content/docs/deployments/deployments/runs/_index.md
+++ b/content/docs/deployments/deployments/runs/_index.md
@@ -1,0 +1,17 @@
+---
+title: Runs
+title_tag: Deployment runs | Pulumi Deployments
+meta_desc: How Pulumi Cloud executes your deployments. Choose the container image that runs your code and the workflow runner it runs on.
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+  deployments:
+    name: Runs
+    parent: deployments-deployments
+    identifier: deployments-deployments-runs
+    weight: 40
+---
+
+Every Pulumi Deployment runs in a container image on a workflow runner. Two settings control how that run works:
+
+- The [image](/docs/deployments/deployments/runs/images/): a Pulumi-managed Linux image by default, or a custom image when your project needs extra tools.
+- The [runner](/docs/deployments/deployments/runs/customer-managed-agents/): Pulumi-hosted by default, or customer-managed when you need to run on your own infrastructure.

--- a/content/docs/deployments/deployments/runs/customer-managed-agents.md
+++ b/content/docs/deployments/deployments/runs/customer-managed-agents.md
@@ -5,12 +5,13 @@ meta_desc: Self-host workflow runners and get all the power and flexibility of P
 menu:
   deployments:
     name: Customer-managed workflow runners
-    parent: deployments-deployments
-    weight: 40
-    identifier: deployments-deployments-customer-managed-agents
+    parent: deployments-deployments-runs
+    weight: 20
+    identifier: deployments-deployments-runs-customer-managed-agents
 
 aliases:
 - /docs/pulumi-cloud/deployments/customer-managed-agents/
+- /docs/deployments/deployments/customer-managed-agents/
 ---
 
 Customer-Managed Workflow Runners allow you to self-host workflow runners, bringing the same power and flexibility as Pulumi-hosted workflows. Self-hosting your workflow runners comes with many benefits for deployments, [Insights](/docs/insights/) discovery scans, and [policy evaluations](/docs/using-pulumi/crossguard/):

--- a/content/docs/deployments/deployments/runs/images.md
+++ b/content/docs/deployments/deployments/runs/images.md
@@ -1,0 +1,135 @@
+---
+title: Images
+title_tag: Deployment images | Pulumi Deployments
+meta_desc: Understand the container image that runs your Pulumi deployments, when to customize it, and how to add the tools your project needs.
+meta_image: /images/docs/meta-images/docs-meta.png
+menu:
+  deployments:
+    name: Images
+    parent: deployments-deployments-runs
+    weight: 10
+    identifier: deployments-deployments-runs-images
+aliases:
+- /docs/deployments/deployments/execution-environment/
+---
+
+Pulumi Cloud runs your Pulumi program inside a container image called the *deployment executor image*. This page covers what is in that image and how to customize it.
+
+## The default executor image
+
+By default, every deployment runs in [`pulumi/pulumi`](https://hub.docker.com/r/pulumi/pulumi), a Linux image that includes:
+
+- The `pulumi` CLI on `$PATH`
+- [LTS versions](https://github.com/pulumi/pulumi-docker-containers/blob/main/README.md#version-policy) of all supported language runtimes: Node.js, Python, Go, .NET, and Java
+- Common build tools: `git`, `curl`, and the package manager for each runtime
+
+For most projects this is the right choice. The image is updated with every Pulumi CLI release, security-patched on a regular cadence, and pre-cached on Pulumi-hosted workflow runners, so deployments start quickly without paying a registry pull.
+
+The image is published in [`pulumi/pulumi-docker-containers`](https://github.com/pulumi/pulumi-docker-containers). That repository also publishes smaller variants you can use as a base for a custom image. See [Choosing a base image](#choosing-a-base-image) below.
+
+## When to customize
+
+You need a different setup when your deployment depends on something not in the default image. Common cases:
+
+- A CLI such as `gh` or `aws` that your Pulumi program or a deployment hook invokes
+- A language runtime version different from the LTS in the default image
+- A system package required by a native dependency
+- A private credential helper
+
+There are two ways to handle this. Pick based on how often you need the tool and how much you care about deployment speed.
+
+## Choosing the right approach
+
+| Approach | Best for | Cost |
+|---|---|---|
+| **Pre-run commands** | One-off tools, scripts, or quick experiments | The install runs on every deployment, adding setup time to each run |
+| **Custom executor image** | Stable tool sets used on every deployment | Slower cold starts on fresh runners, and an image you have to maintain |
+
+## Pre-run commands
+
+If you need a tool occasionally, or you are still prototyping, install it from a [pre-run command](/docs/deployments/deployments/using/settings/#pre-run-commands) in your deployment settings:
+
+```bash
+apt-get update && apt-get install -y my-tool
+```
+
+Pros:
+
+- No image to build or maintain
+- Easy to change: edit the command and the next deployment picks it up
+- Works with the default `pulumi/pulumi` image, so cold starts stay fast
+
+Cons:
+
+- The install runs on every deployment, adding wall-clock time
+- Network failures during the install fail the deployment
+- Not suitable for very large installs
+
+Reach for a custom image only when the install cost starts to hurt.
+
+## Custom executor image
+
+A custom executor image is a container image you build, host, and reference from your stack's deployment settings. Pulumi pulls it before running each deployment.
+
+### Choosing a base image
+
+Pick the smallest base that has the language runtime(s) you need. Pull time scales with image size, so a smaller base means faster first deployments on fresh runners.
+
+| Base image | Size (approx.) | Contents | Best for |
+|---|---|---|---|
+| `pulumi/pulumi-base` | ~200 MB | `pulumi` CLI only | You will install your own language runtime, or use a single language version not in the SDK images |
+| `pulumi/pulumi-nodejs`, `pulumi-python`, `pulumi-go`, `pulumi-dotnet`, `pulumi-java` | 200–400 MB | `pulumi` plus one language runtime | Single-language projects |
+| `pulumi/pulumi` | ~2 GB | `pulumi` plus all language runtimes | Polyglot projects, or when you do not want to pick a runtime |
+
+If you do not need every language runtime, start from `pulumi/pulumi-base` or a language-specific variant. The full `pulumi/pulumi` image is convenient but copies ~2 GB of layers your project will not use.
+
+All variants are listed in the [`pulumi/pulumi-docker-containers` README](https://github.com/pulumi/pulumi-docker-containers/blob/main/README.md).
+
+### Example: adding the GitHub CLI
+
+```dockerfile
+# Pin the Pulumi CLI version explicitly. Floating tags like :latest mean the
+# image and your local CLI can drift apart between deployments.
+FROM pulumi/pulumi-base:3.236.0
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+Build, push to a registry your deployment runner can reach, then point your stack at it from the [Custom Executor Image setting](/docs/deployments/deployments/using/settings/#custom-executor-images) or the `executorContext.executorImage` field of the [REST API](/docs/reference/cloud-rest-api/deployments/).
+
+### Image requirements
+
+A custom executor image must:
+
+- Be a Linux image
+- Include `curl` on `$PATH`
+- Include the `pulumi` CLI on `$PATH`
+- Include the language runtime(s) for the projects that will use it
+- Use a glibc-based libc. Most Pulumi resource provider plugins are glibc-linked, so musl-only images such as Alpine are not supported
+
+If you start from one of the `pulumi/*` base images, all of these are already true.
+
+### Trade-offs
+
+#### Cold starts
+
+The default image is pre-cached on Pulumi-hosted workflow runners. Custom images are not. Every newly-provisioned runner pulls your image from its registry the first time it runs your deployment, which can add minutes to the "Preparing environment" phase.
+
+To reduce cold-start time:
+
+- Start from a small base (`pulumi-base` or a single-language variant)
+- Host the image close to the runner. Pulumi-hosted runners run in AWS `us-west-2`, so an image in a `us-west-2` ECR is faster than one on Docker Hub.
+- Pin a digest so the runner can rely on its layer cache between deployments instead of re-fetching by tag.
+
+#### Static credentials only
+
+If your image lives in a private registry, you must supply static username and password credentials in the deployment settings. OIDC and IAM-role-based pulls are not supported for custom executor images. If your security model requires short-lived registry credentials, [Customer-Managed Workflow Runners](/docs/deployments/deployments/runs/customer-managed-agents/) run in your own infrastructure and can use whatever pull mechanism you configure.
+
+## See also
+
+- [Deployment settings](/docs/deployments/deployments/using/settings/): UI walkthrough for configuring the executor image on a stack
+- [Customer-Managed Workflow Runners](/docs/deployments/deployments/runs/customer-managed-agents/): full control over the runner host, registry pulls, network access, and lifecycle
+- [Pre-run commands](/docs/deployments/deployments/using/settings/#pre-run-commands): where pre-run installs run
+- [`pulumi/pulumi-docker-containers`](https://github.com/pulumi/pulumi-docker-containers): image source, variants, and contribution guide

--- a/content/docs/deployments/deployments/security-and-operations.md
+++ b/content/docs/deployments/deployments/security-and-operations.md
@@ -18,7 +18,7 @@ aliases:
 
 ## Security and Isolation
 
-Deployments run on single-use virtual machines and compute and storage are never shared across runs. We designed our architecture to maximize isolation. In addition, security features like OIDC allow you to fine tune credential scope, lifetime, and expiration policies at a per-deployment level. It is also possible to use [customer-managed workflow runners](/docs/deployments/deployments/customer-managed-agents/) if you require additional isolation. The same isolation applies to all workflow types supported by workflow runners, including [Insights](/docs/insights/) discovery scans and [policy evaluations](/docs/using-pulumi/crossguard/).
+Deployments run on single-use virtual machines and compute and storage are never shared across runs. We designed our architecture to maximize isolation. In addition, security features like OIDC allow you to fine tune credential scope, lifetime, and expiration policies at a per-deployment level. It is also possible to use [customer-managed workflow runners](/docs/deployments/deployments/runs/customer-managed-agents/) if you require additional isolation. The same isolation applies to all workflow types supported by workflow runners, including [Insights](/docs/insights/) discovery scans and [policy evaluations](/docs/using-pulumi/crossguard/).
 
 ## Deployment queue
 

--- a/content/docs/deployments/deployments/using/settings.md
+++ b/content/docs/deployments/deployments/using/settings.md
@@ -53,9 +53,9 @@ When using Pulumi Deployments, you have options for where your workflows run:
 - **Pulumi Hosted Pool**: Managed by Pulumi and available to all Pulumi Cloud customers
 - **Customer-Managed Workflow Runners**: Self-hosted runners that can access private networks and resources, supporting deployments, [Insights](/docs/insights/) discovery scans, and [policy evaluations](/docs/using-pulumi/crossguard/)
 
-If a stack does not have a pool explicitly configured, the deployment uses the organization's [default workflow runner pool](../../customer-managed-agents/#setting-an-organization-default-pool) if one is set, and otherwise falls back to the Pulumi Hosted Pool.
+If a stack does not have a pool explicitly configured, the deployment uses the organization's [default workflow runner pool](/docs/deployments/deployments/runs/customer-managed-agents/#setting-an-organization-default-pool) if one is set, and otherwise falls back to the Pulumi Hosted Pool.
 
-For more information on customer-managed workflow runners, see the [Customer-Managed Workflow Runners documentation](../../customer-managed-agents).
+For more information on customer-managed workflow runners, see the [Customer-Managed Workflow Runners documentation](/docs/deployments/deployments/runs/customer-managed-agents/).
 
 ### Role assignment
 
@@ -110,27 +110,11 @@ By default, when multiple deployments are pushed, they will be executed sequenti
 
 ## Custom Executor Images
 
-By default, the deployment is executed using the [pulumi/pulumi](https://hub.docker.com/r/pulumi/pulumi) image.
-The pulumi/pulumi image is a unix-based image which includes the pulumi CLI in its `$PATH` and the [LTS versions](https://github.com/pulumi/pulumi-docker-containers/blob/main/README.md#version-policy) of all supported SDK runtime(s) for your Pulumi program.
-
-However, there may be scenarios where you might want to customize the image used for the execution, e.g. if you want to use a different version of python or need to include additional dependencies.
-
-This is possible by specifying a custom executor image for your deployment. Using the custom executor image field, you can pin to a specific version of the pulumi/pulumi image,
-or point to a completely custom image hosted in a public or private container registry.
+By default, deployments run inside the [`pulumi/pulumi`](https://hub.docker.com/r/pulumi/pulumi) image, which includes the `pulumi` CLI and [LTS versions](https://github.com/pulumi/pulumi-docker-containers/blob/main/README.md#version-policy) of all supported language runtimes. You can override this from the **Custom Executor Image** field in your stack's deployment settings, either to pin a specific Pulumi CLI version or to use your own image with additional tools.
 
 ![Pulumi UI - Custom Executor](../../ui-custom-executor.png)
 
-Image requirements:
-
-- It must be a unix-based image which includes `curl`.
-- It must include the `pulumi` CLI in its `$PATH`.
-- It must include the required SDK runtime(s) for your Pulumi program.
-
-{{% notes "info" %}}
-Using a custom image may result in slower execution due to time spent pulling the image.
-
-Additionally, we only support static credentials in custom executor images.
-{{% /notes %}}
+For guidance on choosing between a pre-run install hook and a custom image, building a custom image, supported base images, and the trade-offs to consider, see [Deployment execution environment](/docs/deployments/deployments/runs/images/).
 
 ## Open ID Connect (OIDC)
 
@@ -147,7 +131,7 @@ For details on supported clouds see [OIDC Setup for Pulumi Deployments](/docs/de
 When using Pulumi-managed agents, you can speed up deployments using dependency caching.
 
 {{% notes type="info" %}}
-If you have configured the stack to use a [Customer-managed agent](/docs/deployments/deployments/customer-managed-agents/) runner pool this option is unavailable. Running a customer-managed agent pool gives you full control over the lifetime of the agent and its caching.
+If you have configured the stack to use a [Customer-managed agent](/docs/deployments/deployments/runs/customer-managed-agents/) runner pool this option is unavailable. Running a customer-managed agent pool gives you full control over the lifetime of the agent and its caching.
 {{% /notes %}}
 
 The caching method is simple: during the first deployment, the deployment agent will automatically detect downloaded dependencies using lock files, zip them up and store the archive in blob storage. During all subsequent deployments, agents will pull such an archive down and unpack it, saving time it would normally take to download those dependencies. When your dependencies change, deployment agents will automatically invalidate the old cache and create a new one.

--- a/content/docs/insights/self-hosted.md
+++ b/content/docs/insights/self-hosted.md
@@ -10,7 +10,7 @@ menu:
     weight: 50
 ---
 
-Pulumi Insights supports self-hosted operation for Business Critical customers through [customer-managed workflow runners](/docs/deployments/deployments/customer-managed-agents/). This allows you to run [discovery scans](/docs/insights/discovery/) and [policy evaluations](/docs/insights/policy/) within your own infrastructure, giving you full control over where your data is processed while retaining the power of Pulumi Insights.
+Pulumi Insights supports self-hosted operation for Business Critical customers through [customer-managed workflow runners](/docs/deployments/deployments/runs/customer-managed-agents/). This allows you to run [discovery scans](/docs/insights/discovery/) and [policy evaluations](/docs/insights/policy/) within your own infrastructure, giving you full control over where your data is processed while retaining the power of Pulumi Insights.
 
 {{% notes "info" %}}
 Self-hosted Insights is available on the Business Critical edition of Pulumi Cloud. [Contact sales](/contact/?form=sales) if you are interested in enabling this feature.
@@ -29,25 +29,25 @@ Running Insights in your own environment with customer-managed workflow runners 
 
 Customer-managed workflow runners support multiple workflow types beyond deployments, including Insights discovery scans and policy evaluations. Workflow runners poll Pulumi Cloud for pending workflows and execute them in your self-hosted environment.
 
-For full setup and configuration details, see the [customer-managed workflow runners](/docs/deployments/deployments/customer-managed-agents/) documentation.
+For full setup and configuration details, see the [customer-managed workflow runners](/docs/deployments/deployments/runs/customer-managed-agents/) documentation.
 
 ### Setting up Insights scans
 
-1. [Set up a customer-managed workflow runner pool](/docs/deployments/deployments/customer-managed-agents/#using-customer-managed-workflow-runners)
+1. [Set up a customer-managed workflow runner pool](/docs/deployments/deployments/runs/customer-managed-agents/#using-customer-managed-workflow-runners)
 1. Navigate to **Management** > **Accounts** in Pulumi Cloud
 1. Select the workflow runner pool for the account you want to scan
 1. Trigger a scan and confirm it completes successfully
 
 ### Setting up policy evaluations
 
-1. [Set up a customer-managed workflow runner pool](/docs/deployments/deployments/customer-managed-agents/#using-customer-managed-workflow-runners)
+1. [Set up a customer-managed workflow runner pool](/docs/deployments/deployments/runs/customer-managed-agents/#using-customer-managed-workflow-runners)
 1. Navigate to **Management** > **Policies** > **Policy Groups** in Pulumi Cloud
 1. Select the workflow runner pool for an audit policy group
 1. Run a policy evaluation against a stack and confirm the results appear as expected
 
 ### Using an organization default pool
 
-If you want every account scan and policy evaluation to use a customer-managed pool by default, you can set an [organization default workflow runner pool](/docs/deployments/deployments/customer-managed-agents/#setting-an-organization-default-pool). When set, scans and policy groups without an explicit pool use the organization default instead of the Pulumi Hosted Pool.
+If you want every account scan and policy evaluation to use a customer-managed pool by default, you can set an [organization default workflow runner pool](/docs/deployments/deployments/runs/customer-managed-agents/#setting-an-organization-default-pool). When set, scans and policy groups without an explicit pool use the organization default instead of the Pulumi Hosted Pool.
 
 ### Restricting workflow types
 
@@ -59,4 +59,4 @@ enabled_workflow_types:
     - policy_evaluation
 ```
 
-For the full list of configuration options, see the [configuration reference](/docs/deployments/deployments/customer-managed-agents/#configuration-reference).
+For the full list of configuration options, see the [configuration reference](/docs/deployments/deployments/runs/customer-managed-agents/#configuration-reference).


### PR DESCRIPTION
> [Fixture] mirrors pulumi/docs#18831 — body copied verbatim from upstream below.

---Move the buried "Custom Executor Images" subsection from `using/settings.md` to a dedicated `Deployment execution environment` page covering: the default image, when to customize, the choice between pre-run install hooks and custom images, a worked Dockerfile example extending `pulumi-base`, and the cold-start and static-credential trade-offs.

The settings.md section becomes a short stub that keeps the UI screenshot context and links out to the new page.

Fixes pulumi/pulumi-service#42010.