### PR TITLE
docs: link the serverless landing page to serverless templates

### DIFF
--- a/content/topics/serverless.md
+++ b/content/topics/serverless.md
@@ -42,6 +42,8 @@ sections:
       label: Serverless Building Blocks
     - id: code
       label: Code
+    - id: templates
+      label: Templates
     - id: get-started
       label: Get Started
     - id: contact

--- a/layouts/topics/serverless.html
+++ b/layouts/topics/serverless.html
@@ -110,6 +110,42 @@
         {{ end }}
     </section>
 
+    <section id="templates" class="py-16 px-4">
+        <div class="container md:mx-auto md:max-w-4xl text-center">
+            <h3>Deploy with a serverless template</h3>
+            <p>
+                Pulumi serverless application templates provide a complete starting point for a serverless application
+                on AWS, Azure, or Google Cloud. Each template provisions the cloud functions, storage, and supporting
+                resources you need, so you can focus on your application code.
+            </p>
+        </div>
+        <div class="container mx-auto max-w-4xl mt-8">
+            <div class="tiles flex-wrap mt-4">
+                <div class="pb-4 md:pr-4 md:w-1/3">
+                    <a class="tile p-8" href="/templates/serverless-application/aws/">
+                        <img class="h-10 mx-auto" src="/logos/tech/aws.svg" alt="" />
+                        <p class="text-center mt-4">Deploy on AWS</p>
+                    </a>
+                </div>
+                <div class="pb-4 md:pr-4 md:w-1/3">
+                    <a class="tile p-8" href="/templates/serverless-application/azure/">
+                        <img class="h-10 mx-auto" src="/logos/tech/azure.svg" alt="" />
+                        <p class="text-center mt-4">Deploy on Azure</p>
+                    </a>
+                </div>
+                <div class="pb-4 md:w-1/3">
+                    <a class="tile p-8" href="/templates/serverless-application/gcp/">
+                        <img class="h-10 mx-auto" src="/logos/tech/gcp.svg" alt="" />
+                        <p class="text-center mt-4">Deploy on Google Cloud</p>
+                    </a>
+                </div>
+            </div>
+            <p class="text-center mt-8">
+                <a href="/templates/serverless-application/">Browse all serverless templates &rarr;</a>
+            </p>
+        </div>
+    </section>
+
     {{ partial "how-pulumi-works.html" . }}
 
     {{ partial "get-started.html" . }}


### PR DESCRIPTION
> [Fixture] mirrors pulumi/docs#18799 — body copied verbatim from upstream below.

---The `/serverless` landing page is a top search result for "pulumi serverless" but currently has no link to the serverless application templates at `/templates/serverless-application/`. Visitors landing on this page have no clear path to the fastest way to get started building serverless apps with Pulumi.

This PR adds a "Deploy with a serverless template" section between the code examples and the "How Pulumi Works" section. The section contains three tiles linking to the AWS, Azure, and Google Cloud serverless application templates, along with a "Browse all serverless templates" link to the index page.

Changes:
- `content/topics/serverless.md`: Added `templates` entry to the `sections` front-matter array (for consistency with the page structure).
- `layouts/topics/serverless.html`: Added `<section id="templates">` with cloud provider tiles and a browse link, using the same `tile` CSS class pattern as the existing get-started partial.

Resolves #11637

---
🧠 *This PR was created by [workprentice](https://github.com/workprenticebot) on behalf of @joeduffy.*