### PR TITLE
docs(rbac): clarify auth_policies:update is sufficient for OIDC policy edits

### DIFF
--- a/content/docs/administration/access-identity/rbac/scopes/org-settings.md
+++ b/content/docs/administration/access-identity/rbac/scopes/org-settings.md
@@ -124,7 +124,7 @@ These scopes control access to the legacy Pulumi Copilot conversation API, curre
 | `oidc_issuers:regenerate_thumbprints` | Regenerate security thumbprints for an OIDC issuer. This is used to maintain secure authentication.<br><br>**Granted by default roles**: `Admin` |
 | `oidc_issuers:update` | Modify OIDC issuer settings. This allows updating identity provider details and authentication parameters.<br><br>**Granted by default roles**: `Admin` |
 | `auth_policies:read` | View authentication policy configurations. This includes access to OIDC, SAML, and other identity provider settings.<br><br>**Granted by default roles**: `Admin` |
-| `auth_policies:update` | Modify authentication policies and identity provider settings. This allows updating security configurations.<br><br>**Granted by default roles**: `Admin` |
+| `auth_policies:update` | Modify authentication policies and identity provider settings. Sufficient on its own to edit OIDC auth policies, regardless of the token types they reference.<br><br>**Granted by default roles**: `Admin` |
 
 ## Organization
 

--- a/content/docs/administration/access-identity/rbac/scopes/org-settings.md
+++ b/content/docs/administration/access-identity/rbac/scopes/org-settings.md
@@ -241,3 +241,5 @@ These scopes control access to the legacy Pulumi Copilot conversation API, curre
 | `templates_source:delete` | Allows removing template sources from the organization.<br><br>**Granted by default roles**: `Admin` |
 | `templates_source:read` | Allows viewing template source configurations and available templates.<br><br>**Granted by default roles**: `Admin` |
 | `templates_source:update` | Allows modifying template source configurations and settings.<br><br>**Granted by default roles**: `Admin` |
+
+<!-- reconcile-stale-probe -->


### PR DESCRIPTION
> [Fixture] mirrors pulumi/docs#18805 — body copied verbatim from upstream below. 2026-07-30 triple-PR regression run (#20518 + #20577 + #20546).

---## Summary
- Updates the `auth_policies:update` row in the org-settings RBAC scope reference to clarify that this permission alone is sufficient to edit an OIDC auth policy, regardless of the token types (`personal`, `team`, `organization`) the policy references.