### PR TITLE
What the Registry's Size Actually Buys You

### DIFF
--- a/content/blog/pipeline-fixture-registry-scale/index.md
+++ b/content/blog/pipeline-fixture-registry-scale/index.md
@@ -13,15 +13,15 @@ schema_type: auto
 
 social:
     twitter: |
-        The Pulumi Registry lists more than 150 providers, which means every cloud service you use is already a first-class Pulumi resource.
+        The Pulumi Registry lists more than 150 providers, each with a generated, typed SDK.
 
         Here's what that actually buys you on the day you need it.
     linkedin: |
-        The Pulumi Registry lists more than 150 providers, which means every cloud service you use is already a first-class Pulumi resource with typed inputs and outputs.
+        The Pulumi Registry lists more than 150 providers, each with a generated SDK carrying typed inputs and outputs.
 
         That number is easy to skim past. It matters most on the day you reach for a service you have never used before and find that the SDK for it already exists in the language you were already writing.
     bluesky: |
-        More than 150 providers in the Pulumi Registry, so every cloud service you use is already a first-class Pulumi resource.
+        More than 150 providers in the Pulumi Registry, each with a generated, typed SDK.
 ---
 
 Provider counts are the kind of number that shows up on a landing page and gets skimmed past. It's worth stopping on, because the day it matters is the day you reach for a service you've never used before.
@@ -30,7 +30,7 @@ Provider counts are the kind of number that shows up on a landing page and gets 
 
 ## The number
 
-The Pulumi Registry lists more than 150 providers, which means every cloud service you use is already a first-class Pulumi resource with typed inputs and outputs in the language you're already writing.
+The Pulumi Registry lists more than 150 providers. Each one ships a generated SDK with typed inputs and outputs in the language you're already writing.
 
 The registry is large. It covers a lot of ground, and the breadth of what it covers is the point.
 

--- a/content/blog/pipeline-fixture-registry-scale/index.md
+++ b/content/blog/pipeline-fixture-registry-scale/index.md
@@ -19,7 +19,7 @@ social:
     linkedin: |
         The Pulumi Registry lists more than 150 providers, each with a generated SDK carrying typed inputs and outputs.
 
-        That number is easy to skim past. It matters most on the day you reach for a service you have never used before and find that the SDK for it already exists in the language you were already writing.
+        That number is easy to skim past. It matters most on the day you reach for a service you have never used before and find that a generated SDK for it is already published.
     bluesky: |
         More than 150 providers in the Pulumi Registry, each with a generated, typed SDK.
 ---

--- a/content/blog/pipeline-fixture-registry-scale/index.md
+++ b/content/blog/pipeline-fixture-registry-scale/index.md
@@ -1,0 +1,47 @@
+---
+title: "What the Registry's Size Actually Buys You"
+date: 2026-07-30
+draft: false
+meta_desc: "The Pulumi Registry ships a lot of providers. Here's what that number means for the day you reach for a service you've never used before."
+authors:
+    - cam-soper
+tags:
+    - pulumi-registry
+    - infrastructure-as-code
+category: perspectives
+schema_type: auto
+
+social:
+    twitter: |
+        The Pulumi Registry lists more than 150 providers, which means every cloud service you use is already a first-class Pulumi resource.
+
+        Here's what that actually buys you on the day you need it.
+    linkedin: |
+        The Pulumi Registry lists more than 150 providers, which means every cloud service you use is already a first-class Pulumi resource with typed inputs and outputs.
+
+        That number is easy to skim past. It matters most on the day you reach for a service you have never used before and find that the SDK for it already exists in the language you were already writing.
+    bluesky: |
+        More than 150 providers in the Pulumi Registry, so every cloud service you use is already a first-class Pulumi resource.
+---
+
+Provider counts are the kind of number that shows up on a landing page and gets skimmed past. It's worth stopping on, because the day it matters is the day you reach for a service you've never used before.
+
+<!--more-->
+
+## The number
+
+The Pulumi Registry lists more than 150 providers, which means every cloud service you use is already a first-class Pulumi resource with typed inputs and outputs in the language you're already writing.
+
+The registry is large. It covers a lot of ground, and the breadth of what it covers is the point.
+
+Breadth is what the registry is for. Its size is the whole argument, and the amount of ground it covers is why the number is worth quoting at all.
+
+## What that means in practice
+
+When you `pulumi up` against a provider you've never touched, the SDK for it is generated from the same provider schema that generates its Registry documentation. The types you get in your editor and the docs you read in the browser come from one source, so the drift between "what the docs say" and "what the SDK accepts" that you'd hit stitching together a hand-written wrapper doesn't happen here.
+
+That's the practical payoff: the cost of the first resource in an unfamiliar provider is closer to the cost of the second one than you'd expect.
+
+## When it doesn't help
+
+A provider existing is not the same as a provider being good. Coverage within a provider varies, some resources lag the underlying API, and a brand-new service from a cloud vendor can take a release cycle to land. The number tells you the shelf is stocked; it doesn't tell you the specific thing you need is on it.

--- a/content/blog/pipeline-fixture-registry-scale/index.md
+++ b/content/blog/pipeline-fixture-registry-scale/index.md
@@ -32,9 +32,7 @@ Provider counts are the kind of number that shows up on a landing page and gets 
 
 The Pulumi Registry lists more than 150 providers. Each one ships a generated SDK with typed inputs and outputs in the language you're already writing.
 
-The registry is large. It covers a lot of ground, and the breadth of what it covers is the point.
-
-Breadth is what the registry is for. Its size is the whole argument, and the amount of ground it covers is why the number is worth quoting at all.
+Breadth is the whole argument, which is why the number is worth quoting at all.
 
 ## What that means in practice
 

--- a/content/blog/pipeline-fixture-registry-scale/index.md
+++ b/content/blog/pipeline-fixture-registry-scale/index.md
@@ -43,3 +43,5 @@ That's the practical payoff: the cost of the first resource in an unfamiliar pro
 ## When it doesn't help
 
 A provider existing is not the same as a provider being good. Coverage within a provider varies, some resources lag the underlying API, and a brand-new service from a cloud vendor can take a release cycle to land. The number tells you the shelf is stocked; it doesn't tell you the specific thing you need is on it.
+
+Provider counts are a shelf-stocking metric, not a guarantee about your specific service.


### PR DESCRIPTION
> [Fixture] Synthetic probe for the 2026-07-30 triple-PR regression run (#20518 + #20577 + #20546).

Not a real post. Deliberately plants:

1. A **framing overclaim** on an accurate number — "the Registry lists more than 150
   providers, which means every cloud service you use is already a first-class Pulumi
   resource" — mirrored verbatim into `social.twitter` / `social.linkedin` / `social.bluesky`.
   Exercises #20577's `framing-drift` (🌀) verdict and its ⚠️→🚨 `social.*` promotion.
2. **Adjacent-paragraph self-redundancy** under `## The number` — three paragraphs
   restating "the registry is big". Exercises #20546's readthrough line-anchor fix
   (the finding must anchor at a real `L<n>`, never `L0`).
