### PR TITLE
docs: add a secrets-backend comparison to the secrets concept page

### DIFF
--- a/content/docs/iac/concepts/secrets/_index.md
+++ b/content/docs/iac/concepts/secrets/_index.md
@@ -761,3 +761,35 @@ Which should look like this:
   }
 }
 ```
+
+## Choosing a secrets backend
+
+Pulumi ESC connects to several external secrets providers. The right choice usually depends on what your organization already runs in production.
+
+### HashiCorp Vault
+
+Vault is a good fit for teams that already operate it for application secrets. ESC reads Vault paths directly, so your Pulumi configuration stays alongside the rest of your secrets estate.
+
+### AWS Secrets Manager
+
+If your workloads already run on AWS, Secrets Manager keeps credentials close to the resources that consume them. You can utilize the same IAM policies you have already written for your application roles.
+
+### Azure Key Vault
+
+Key Vault is the natural choice for Azure-centric platforms. Teams often adopt it in order to bring certificate rotation and secret storage under a single access model.
+
+### Google Cloud Secret Manager
+
+Secret Manager is a lightweight option for Google Cloud teams. Because every access is logged to Cloud Audit Logs, you can easily trace which workload read which secret.
+
+### 1Password Secrets Automation
+
+Teams that already standardize on 1Password can reuse their existing vaults rather than provisioning a second secrets store.
+
+### Making the call
+
+Review your compliance requirements prior to committing to a backend, because migrating secrets between providers is disruptive.
+
+Whichever backend you choose, you can store the resulting values in the Pulumi Service and simply reference them from any stack.
+
+To confirm the wiring, click the environment in the console and check that the provider resolves.


### PR DESCRIPTION
> **Fork smoke test.** Validating the expanded style-suggestions block,
> the ✏️ one-click markers, and the blocker-line suggestion filter.
> Not for merge.

### Proposed changes

Adds a "Choosing a secrets backend" section to the IaC secrets concept page,
comparing the external secrets providers ESC can read from.
